### PR TITLE
Close #20: rewrite lost strict localizer

### DIFF
--- a/src/Applications/NodeGossiper.py
+++ b/src/Applications/NodeGossiper.py
@@ -180,55 +180,55 @@ class ggParameters:
                 i = int(a)
             except:
                 i = None
-            if o == "-h":
+            if o == '-h':
                 self.usage()
                 sys.exit(0)
-            elif o == "-v":
+            elif o == '-v':
                 self.verbose = True
-            elif o == "-c":
+            elif o == '-c':
                 self.criterion = i 
-            elif o == "-i":
+            elif o == '-i':
                 if i > -1:
                     self.n_iterations = i
-            elif o == "-s":
+            elif o == '-s':
                 if i > -1:
                     self.time_step = i
-            elif o == "-x":
+            elif o == '-x':
                 if i > 0:
                     self.grid_size[0] = i
-            elif o == "-y":
+            elif o == '-y':
                 if i > 0:
                     self.grid_size[1] = i
-            elif o == "-z":
+            elif o == '-z':
                 if i > 0:
                     self.grid_size[2] = i
-            elif o == "-o":
+            elif o == '-o':
                 if i > 0:
                     self.n_objects = i
-            elif o == "-p":
+            elif o == '-p':
                 if i > 0:
                     self.n_processors = i
-            elif o == "-d":
+            elif o == '-d':
                 if i > 0:
                     self.communication_degree = i
                     self.communication_enabled = True
-            elif o == "-t":
+            elif o == '-t':
                 self.time_sampler_type, self.time_sampler_parameters = parse_sampler(a)
-            elif o == "-w":
+            elif o == '-w':
                 self.weight_sampler_type, self.weight_sampler_parameters = parse_sampler(a)
-            elif o == "-k":
+            elif o == '-k':
                 if i > 0:
                     self.n_rounds = i
-            elif o == "-f":
+            elif o == '-f':
                 if i > 0:
                     self.fanout = i
-            elif o == "-r":
+            elif o == '-r':
                 x = float(a)
                 if x > 1.:
                     self.threshold = x
-            elif o == "-l":
+            elif o == '-l':
                 self.log_file = a
-            elif o == "-m":
+            elif o == '-m':
                 self.map_file = a
 
 	# Ensure that exactly one population strategy was chosen

--- a/src/Execution/lbsCriterion.py
+++ b/src/Execution/lbsCriterion.py
@@ -30,7 +30,7 @@
 # ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
 # LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
 # CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# SUBSTITUTE GOlODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
@@ -83,6 +83,7 @@ class Criterion(object):
 
         #Try to load corresponding module
         m_name = "Execution.lbs{}".format(c_name)
+        module = importlib.import_module(m_name)
         try:
             module = importlib.import_module(m_name)
         except:
@@ -98,7 +99,7 @@ class Criterion(object):
                 c_name,
                 m_name))
             return None
-            
+
         # Instantiate and return object
         ret_object = c_class(processors, edges, parameters)
         print("[Criterion] Instantiated {} load transfer criterion".format(

--- a/src/Execution/lbsRelaxedLocalizingCriterion.py
+++ b/src/Execution/lbsRelaxedLocalizingCriterion.py
@@ -1,5 +1,3 @@
-#
-#@HEADER
 ###############################################################################
 #
 #                       lbsRelaxedLocalizingCriterion.py
@@ -39,17 +37,14 @@
 # Questions? Contact darma@sandia.gov
 #
 ###############################################################################
-#@HEADER
-#
-########################################################################
 from lbsCriterionBase import CriterionBase
 
-########################################################################
+###############################################################################
 class RelaxedLocalizingCriterion(CriterionBase):
     """A concrete class for a relaxedly localizing criterion
     """
 
-    ####################################################################
+    ###########################################################################
     def __init__(self, processors, edges, _):
         """Class constructor:
         processors: set of processors (lbsProcessor.Processor instances)
@@ -61,7 +56,7 @@ class RelaxedLocalizingCriterion(CriterionBase):
         super(RelaxedLocalizingCriterion, self).__init__(processors, edges)
         print("[RelaxedLocalizingCriterion] Instantiated concrete criterion")
         
-    ####################################################################
+    ###########################################################################
     def compute(self, object, p_src, p_dst):
         """A criterion allowing for local disruptions for more locality 
         """
@@ -96,4 +91,4 @@ class RelaxedLocalizingCriterion(CriterionBase):
         # Criterion assesses difference in local communications
         return w_dst - w_src
 
-########################################################################
+###############################################################################

--- a/src/Execution/lbsRuntime.py
+++ b/src/Execution/lbsRuntime.py
@@ -254,8 +254,18 @@ class Runtime:
                             p_cmf)
 
                         # Decide about proposed transfer
-                        if transfer_criterion.compute(o, p_src, p_dst) > 0.:
-                            # Report on accepted object transfer when requested
+                        if transfer_criterion.compute(o, p_src, p_dst) < 0.:
+                            # Reject proposed transfer
+                            n_rejects += 1
+
+                            # Report on rejected object transfer when requested
+                            if self.verbose:
+                                print("\t\tprocessor {} declined transfer of object {} ({})".format(
+                                    p_dst.get_id(),
+                                    o.get_id(),
+                                    o.get_time()))
+                        else:
+                            # Accept proposed transfer
                             if self.verbose:
                                 print("\t\ttransfering object {} ({}) to processor {}".format(
                                     o.get_id(),
@@ -268,16 +278,6 @@ class Runtime:
                             p_dst.objects.add(o)
                             l_exc -= o.get_time()
                             n_transfers += 1
-                        else:
-                            # Transfer was declined
-                            n_rejects += 1
-
-                            # Report on rejected object transfer when requested
-                            if self.verbose:
-                                print("\t\tprocessor {} declined transfer of object {} ({})".format(
-                                    p_dst.get_id(),
-                                    o.get_id(),
-                                    o.get_time()))
 
             # Edges cache is no longer current
             self.phase.invalidate_edges()

--- a/src/Execution/lbsStrictLocalizingCriterion.py
+++ b/src/Execution/lbsStrictLocalizingCriterion.py
@@ -70,14 +70,14 @@ class StrictLocalizingCriterion(CriterionBase):
         # Iterate over sent messages
         for i in comm.get_sent().items():
             if p_src_id == i[0].get_processor_id():
-                # Bail out as soon as locality can be broken
-                return 0.
+                # Bail out as soon as locality is broken by transfer
+                return -1.
 
         # Iterate over received messages
         for i in comm.get_received().items():
             if p_src_id == i[0].get_processor_id():
-                # Bail out as soon as locality can be broken
-                return 0.
+                # Bail out as soon as locality is broken by transfer
+                return -1.
 
         # Criterion returns a positive value meaning acceptance
         return 1.

--- a/src/Execution/lbsStrictLocalizingCriterion.py
+++ b/src/Execution/lbsStrictLocalizingCriterion.py
@@ -1,0 +1,85 @@
+###############################################################################
+#
+#                       lbsStrictLocalizingCriterion.py
+#                           DARMA Toolkit v. 1.0.0
+#               DARMA/LB-analysis-framework => LB Analysis Framework
+#
+# Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+# Government retains certain rights in this software.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from this
+#   software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Questions? Contact darma@sandia.gov
+#
+###############################################################################
+from lbsCriterionBase import CriterionBase
+
+###############################################################################
+class StrictLocalizingCriterion(CriterionBase):
+    """A concrete class for a strictly localizing criterion
+    """
+    
+    ###########################################################################
+    def __init__(self, processors, edges, _):
+        """Class constructor:
+        processors: set of processors (lbsProcessor.Processor instances)
+        edges: dictionary of edges (frozensets)
+        _: no parameters dictionary needed for this criterion
+        """
+
+        # Call superclass init
+        super(StrictLocalizingCriterion, self).__init__(processors, edges)
+        print("[StrictLocalizingCriterion] Instantiated concrete criterion")
+        
+    ###########################################################################
+    def compute(self, object, p_src, _):
+        """A criterion enforcing strict conservation of local communications
+        """
+
+        # Keep track source processsor ID
+        p_src_id = p_src.get_id()
+
+        # Retrieve object communications
+        comm = object.get_communicator()
+
+        # Iterate over sent messages
+        for i in comm.get_sent().items():
+            if p_src_id == i[0].get_processor_id():
+                # Bail out as soon as locality can be broken
+                return 0.
+
+        # Iterate over received messages
+        for i in comm.get_received().items():
+            if p_src_id == i[0].get_processor_id():
+                # Bail out as soon as locality can be broken
+                return 0.
+
+        # Criterion returns a positive value meaning acceptance
+        return 1.
+
+###############################################################################

--- a/src/IO/lbsStatistics.py
+++ b/src/IO/lbsStatistics.py
@@ -254,11 +254,11 @@ def print_subset_statistics(var_name, set_name, set_size, subset_name, subset_si
 
     # Print summary
     print("[Statistics] {}:".format(var_name))
-    print("\t{}: {:.6g}  {}: {:.6g} ({:.4g}%)".format(
+    print("\t{}: {:.6g}  {}: {:.6g} {}".format(
         set_name,
         set_size,
         subset_name,
         subset_size,
-        100. * subset_size / set_size))
+        "({:.4g}%)".format(100. * subset_size / set_size) if set_size else ''))
 
 ########################################################################


### PR DESCRIPTION
This PR also improves the overall usage of quantitative criteria (by favoring acceptance of transfer vs rejection in cases of draws).

Reference case:
`./NodeGossiper.py -i 2 -x 4 -y 4 -z 1 -p 4 -o 1024 -k 2 -f 2 -t uniform,1.0,1.0 -w lognormal,0.5,1.0 -d 2`

with the **strictly** localizing criterion (`-c 2`) one obtains:
```
[Statistics] Descriptive statistics of final processor loads:
	cardinality: 16  sum: 1024  imbalance: 2.17188
	minimum: 14  mean: 64  maximum: 203
	standard deviation: 60.024  variance: 3602.88
	skewness: 1.34027  kurtosis excess: 0.154602
[Statistics] Descriptive statistics of final link weights:
	cardinality: 53  sum: 2188.62  imbalance: 6.21218
	minimum: 1.19894  mean: 41.2947  maximum: 297.825
	standard deviation: 80.3113  variance: 6449.9
	skewness: 2.47807  kurtosis excess: 4.40877
```
vs with the **relaxed** localizing criterion (`-c 3`):
```
[Statistics] Descriptive statistics of final processor loads:
	cardinality: 16  sum: 1024  imbalance: 2.15625
	minimum: 18  mean: 64  maximum: 202
	standard deviation: 60.8471  variance: 3702.38
	skewness: 1.27818  kurtosis excess: -0.0584534
[Statistics] Descriptive statistics of final link weights:
	cardinality: 54  sum: 2309.37  imbalance: 6.64766
	minimum: 2.13417  mean: 42.7662  maximum: 327.061
	standard deviation: 84.3261  variance: 7110.9
	skewness: 2.56207  kurtosis excess: 4.88225
```
i.e. and as expected, better **load** balance and worse **weight** balance when the localizer is relaxed.  