### PR TITLE
27 vistool import optional

### DIFF
--- a/src/Applications/AnimationViewer.py
+++ b/src/Applications/AnimationViewer.py
@@ -18,7 +18,14 @@ for m in [
         print("*  WARNING: Failed to import {}. {}.".format(m, e))
         globals()[has_flag] = False
 
-import paraview.simple as pv
+try:
+    import paraview.simple as pv
+    globals()["has_paraview"] = True
+except:
+    globals()["has_paraview"] = False
+    if not __name__ == '__main':
+        print("[AnimationViewer] Failed to import paraview. Cannot save visual artifacts.")
+        sys.exit(0)
 from ParaviewViewer    import ParaviewViewer
 
 if __name__ == '__main__':
@@ -65,6 +72,11 @@ class AnimationViewer(ParaviewViewer):
 
 ###############################################################################
 if __name__ == '__main__':
+
+    # Check if visualization library imported
+    if not has_paraview:
+        print("* ERROR: failed to import paraview. Cannot save visual artifacts.Exiting.")
+        sys.exit(1)
 
     # Print startup information
     sv = sys.version_info

--- a/src/Applications/AnimationViewer.py
+++ b/src/Applications/AnimationViewer.py
@@ -43,10 +43,10 @@ class AnimationViewer(ParaviewViewer):
     """
 
     ###########################################################################
-    def __init__(self, file_name=None, viewer_type=None):
+    def __init__(self, exodus=None, file_name=None, viewer_type=None):
 
         # Call superclass init
-        super(AnimationViewer, self).__init__(file_name, viewer_type)
+        super(AnimationViewer, self).__init__(exodus, file_name, viewer_type)
 
     ###########################################################################
     def saveView(self, reader):
@@ -88,8 +88,9 @@ if __name__ == '__main__':
     # Instantiate parameters and set values from command line arguments
     print("[AnimationViewer] Parsing command line arguments")
     params = ViewerParameters()
-    params.parse_command_line()
-    animationViewer = ParaviewViewerBase.factory(params.file_name, "Animation")
+    if params.parse_command_line():
+        sys.exit(1)
+    animationViewer = ParaviewViewerBase.factory(params.exodus, params.file_name, "Animation")
 
     # Create view from AnimationViewer instance
     reader = animationViewer.createViews()

--- a/src/Applications/NodeGossiper.py
+++ b/src/Applications/NodeGossiper.py
@@ -72,16 +72,16 @@ if __name__ == '__main__':
         from Execution              import lbsRuntime
         from IO                     import lbsLoadWriterVT, lbsWriterExodusII, lbsStatistics
         try:
-            from ParaviewViewerBase     import ParaviewViewerBase
+            from ParaviewViewerBase import ParaviewViewerBase
             globals()["has_paraview"] = True
         except:
             globals()["has_paraview"] = False
     else:
-        from ..Model                import lbsPhase
-        from ..Execution            import lbsRuntime
-        from ..IO                   import lbsLoadWriterVT, lbsWriterExodusII, lbsStatistics
+        from ..Model                  import lbsPhase
+        from ..Execution              import lbsRuntime
+        from ..IO                     import lbsLoadWriterVT, lbsWriterExodusII, lbsStatistics
         try:
-            from ..ParaviewViewerBase   import ParaviewViewerBase
+            from ..ParaviewViewerBase import ParaviewViewerBase
             globals()["has_paraview"] = True
         except:
             globals()["has_paraview"] = False
@@ -143,8 +143,8 @@ class ggParameters:
         # Base name to save computed object/processor mapping for VT
         self.map_file = None
 
-        # Prefix of Exodus type visualization output file
-        self.exodus = None
+        # Decide whether Exodus output should be written
+        self.exodus = False
 
     ###########################################################################
     def usage(self):
@@ -176,8 +176,7 @@ class ggParameters:
         print("\t [-d <d>]    object communication degree "
               "(no communication if 0) ")
         print("\t [-v]        make standard output more verbose")
-        print("\t [-e <exo>]  generate Exodus type visualization output: "
-              "prefix of output")
+        print("\t [-e]        generate Exodus type visualization output")
         print("\t [-h]        help: print this message and exit")
         print('')
 
@@ -190,7 +189,7 @@ class ggParameters:
         try:
             opts, args = getopt.getopt(
                 sys.argv[1:],
-                "c:i:x:y:z:o:p:k:f:r:t:w:s:l:m:d:ve:h")
+                "c:i:x:y:z:o:p:k:f:r:t:w:s:l:m:d:veh")
         except getopt.GetoptError:
             print("** ERROR: incorrect command line arguments.")
             self.usage()
@@ -253,7 +252,7 @@ class ggParameters:
             elif o == '-v':
                 self.verbose = True
             elif o == '-e':
-                self.exodus = a
+                self.exodus = True
             elif o == '-h':
                 self.usage()
                 sys.exit(0)

--- a/src/Applications/NodeGossiper.py
+++ b/src/Applications/NodeGossiper.py
@@ -71,12 +71,20 @@ if __name__ == '__main__':
         from Model                  import lbsPhase
         from Execution              import lbsRuntime
         from IO                     import lbsLoadWriterVT, lbsWriterExodusII, lbsStatistics
-        #from ParaviewViewerBase     import ParaviewViewerBase
+        try:
+            from ParaviewViewerBase     import ParaviewViewerBase
+            globals()["has_paraview"] = True
+        except:
+            globals()["has_paraview"] = False
     else:
         from ..Model                import lbsPhase
         from ..Execution            import lbsRuntime
         from ..IO                   import lbsLoadWriterVT, lbsWriterExodusII, lbsStatistics
-        #from ..ParaviewViewerBase   import ParaviewViewerBase
+        try:
+            from ..ParaviewViewerBase   import ParaviewViewerBase
+            globals()["has_paraview"] = True
+        except:
+            globals()["has_paraview"] = False
 
 ###############################################################################
 class ggParameters:
@@ -433,9 +441,9 @@ if __name__ == '__main__':
                     params.verbose)
 
     # Create a Viewer
-    #viewer = ParaviewViewerBase.factory("{}.e".format(output_stem), "")
-    #reader = viewer.createViews()
-    #viewer.saveView(reader)
+    viewer = ParaviewViewerBase.factory("{}.e".format(output_stem), "")
+    reader = viewer.createViews()
+    viewer.saveView(reader)
 
     # Compute and print final processor load and link weight statistics
     _, _, l_ave, _, _, _, _, _ = lbsStatistics.print_function_statistics(

--- a/src/Applications/NodeGossiper.py
+++ b/src/Applications/NodeGossiper.py
@@ -438,19 +438,20 @@ if __name__ == '__main__':
             "{}".format(output_stem))
         vt_writer.write(params.time_step)
 
-    # Instantiate phase to ExodusII file writer
-    ex_writer = lbsWriterExodusII.WriterExodusII(
-        phase,
-        grid_map,
-        "{}".format(output_stem))
-    ex_writer.write(rt.statistics,
-                    rt.load_distributions,
-                    rt.sent_distributions,
-                    params.verbose)
-
     # If prefix parsed from command line
     if params.exodus:
-        # Create a Viewer
+        # Instantiate phase to ExodusII file writer if requested
+        ex_writer = lbsWriterExodusII.WriterExodusII(
+            phase,
+            grid_map,
+            "{}".format(output_stem))
+        ex_writer.write(rt.statistics,
+                        rt.load_distributions,
+                        rt.sent_distributions,
+                        params.verbose)
+
+    # Create a viewer if paraview is available
+    if globals().get("has_paraview"):
         viewer = ParaviewViewerBase.factory(
             output_stem,
             params.exodus,

--- a/src/Applications/PNGViewer.py
+++ b/src/Applications/PNGViewer.py
@@ -43,10 +43,10 @@ class PNGViewer(ParaviewViewer):
     """
 
     ###########################################################################
-    def __init__(self, file_name=None, viewer_type=None):
+    def __init__(self, exodus=None, file_name=None, viewer_type=None):
 
         # Call superclass init
-        super(PNGViewer, self).__init__(file_name, viewer_type)
+        super(PNGViewer, self).__init__(exodus, file_name, viewer_type)
 
     ###########################################################################
     def saveView(self, reader):
@@ -82,8 +82,9 @@ if __name__ == '__main__':
     # Instantiate parameters and set values from command line arguments
     print("[PNGViewer] Parsing command line arguments")
     params = ViewerParameters()
-    params.parse_command_line()
-    pngViewer = ParaviewViewerBase.factory(params.file_name, "PNG")
+    if params.parse_command_line():
+        sys.exit(1)
+    pngViewer = ParaviewViewerBase.factory(params.exodus, params.file_name, "PNG")
 
     # Create view from PNGViewer instance
     reader = pngViewer.createViews()

--- a/src/Applications/PNGViewer.py
+++ b/src/Applications/PNGViewer.py
@@ -18,7 +18,14 @@ for m in [
         print("*  WARNING: Failed to import {}. {}.".format(m, e))
         globals()[has_flag] = False
 
-import paraview.simple as pv
+try:
+    import paraview.simple as pv
+    globals()["has_paraview"] = True
+except:
+    globals()["has_paraview"] = False
+    if not __name__ == '__main':
+        print("[PNGViewer] Failed to import paraview. Cannot save visual artifacts.")
+        sys.exit(0)
 from ParaviewViewer    import ParaviewViewer
 
 if __name__ == '__main__':
@@ -59,6 +66,11 @@ class PNGViewer(ParaviewViewer):
 
 ###############################################################################
 if __name__ == '__main__':
+
+    # Check if visualization library imported
+    if not has_paraview:
+        print("* ERROR: failed to import paraview. Cannot save visual artifacts.Exiting.")
+        sys.exit(1)
 
     # Print startup information
     sv = sys.version_info

--- a/src/Applications/ParaviewViewer.py
+++ b/src/Applications/ParaviewViewer.py
@@ -37,10 +37,10 @@ class ParaviewViewer(ParaviewViewerBase):
     """
 
     ###########################################################################
-    def __init__(self, file_name=None, viewer_type=None):
+    def __init__(self, exodus=None, file_name=None, viewer_type=None):
 
         # Call superclass init
-        super(ParaviewViewer, self).__init__(file_name, viewer_type)
+        super(ParaviewViewer, self).__init__(exodus, file_name, viewer_type)
 
     ###########################################################################
     def saveView(self, reader):
@@ -68,8 +68,9 @@ if __name__ == '__main__':
     # Instantiate parameters and set values from command line arguments
     print("[ParaviewViewer] Parsing command line arguments")
     params = ViewerParameters()
-    params.parse_command_line()
-    viewer = ParaviewViewerBase.factory(params.file_name, "")
+    if params.parse_command_line():
+        sys.exit(1)
+    viewer = ParaviewViewerBase.factory(params.exodus, params.file_name, "")
 
     # Create view from PNGViewer instance
     reader = viewer.createViews()

--- a/src/Applications/ParaviewViewerBase.py
+++ b/src/Applications/ParaviewViewerBase.py
@@ -21,7 +21,14 @@ for m in [
         print("*  WARNING: Failed to import {}. {}.".format(m, e))
         globals()[has_flag] = False
 
-import paraview.simple as pv
+try:
+    import paraview.simple as pv
+    globals()["has_paraview"] = True
+except:
+    globals()["has_paraview"] = False
+    if not __name__ == '__main':
+        print("*  WARNING: Failed to import paraview. Cannot save visual artifacts.")
+        sys.exit(0)
 
 ###############################################################################
 class ViewerParameters:
@@ -42,6 +49,11 @@ class ViewerParameters:
     def parse_command_line(self):
         """Parse command line
         """
+
+        # Check if visualization library imported
+        if not has_paraview:
+            print("* ERROR: failed to import paraview. Cannot save visual artifacts.Exiting.")
+            sys.exit(1)
 
         # Try to hash command line with respect to allowable flags
         try:
@@ -81,6 +93,11 @@ class ParaviewViewerBase(object):
     ###########################################################################
     @abc.abstractmethod
     def __init__(self, file_name=None, viewer_type=None):
+
+        # Check if visualization library imported
+        if not has_paraview:
+            print("* ERROR: failed to import paraview. Cannot save visual artifacts.Exiting.")
+            sys.exit(1)
 
         # ExodusII file to be displayed and saved
         self.file_name = file_name


### PR DESCRIPTION
Opening new PR since issue description changed.  
Visualization artifacts are now generated when specified in command line with `-e` argument, followed by the string to be used as prefix of viz file naming. Please note that it is possible to specify an empty string in which case, the name of the generated ExodusII file is used by default for viz files too. 