### PR TITLE
#70: Make extension of VOM files a command line option

### DIFF
--- a/src/Applications/MoveCountsViewer.py
+++ b/src/Applications/MoveCountsViewer.py
@@ -59,7 +59,7 @@ class MoveCountsViewer:
     """A class to describe MoveCountsViewer attributes
     """
 
-    def __init__(self):
+    def __init__(self, input_file_suffix="vom"):
 
         # Size of subset to which objects are initially mapped (0 = all)
         self.n_processors = 0
@@ -68,7 +68,7 @@ class MoveCountsViewer:
         self.input_file_name = None
 
         # Input file suffix -- .vom by default
-        self.input_file_suffix = "vom"
+        self.input_file_suffix = input_file_suffix
 
         # Output file name
         self.output_file_name = None

--- a/src/Applications/NodeGossiper.py
+++ b/src/Applications/NodeGossiper.py
@@ -133,6 +133,9 @@ class ggParameters:
         # Generate multimedia
         self.generate_multimedia = False
 
+        # Data files suffix (data loading)
+        self.file_suffix = "vom"
+
     def usage(self):
         """Provide online help
         """
@@ -161,10 +164,11 @@ class ggParameters:
         print("\t [-m <bmap>] base file name for VT object/proc mapping")
         print("\t [-d <d>]    object communication degree "
               "(no communication if 0) ")
+        print("\t [-b <odir>] output directory")
+        print("\t [-j <fsuf>] file suffix for data files(reading data)")
         print("\t [-v]        make standard output more verbose")
         print("\t [-a]        use actual destination loads")
         print("\t [-e]        generate Exodus type visualization output")
-        print("\t [-b]        output directory")
         print("\t [-g]        generate multimedia")
         print("\t [-h]        help: print this message and exit")
         print('')
@@ -177,7 +181,7 @@ class ggParameters:
         try:
             opts, args = getopt.getopt(
                 sys.argv[1:],
-                "ac:i:x:y:z:o:p:k:f:r:t:w:s:l:m:d:b:vehg")
+                "ac:i:x:y:z:o:p:k:f:r:t:w:s:l:m:d:b:j:vehg")
         except getopt.GetoptError:
             print(bcolors.ERR
                 + "** ERROR: incorrect command line arguments."
@@ -252,6 +256,8 @@ class ggParameters:
                 self.generate_multimedia = True
             elif o == '-b':
                 self.output_dir = a
+            elif o == '-j':
+                self.file_suffix = a
 
         # Ensure that exactly one population strategy was chosen
         if (not (self.log_file or
@@ -396,7 +402,7 @@ if __name__ == '__main__':
     initialize()
 
     # Create a phase and populate it
-    phase = Phase(0, params.verbose)
+    phase = Phase(0, params.verbose, file_suffix=params.file_suffix)
     if params.log_file:
         # Populate phase from log files and store number of objects
         n_o = phase.populate_from_log(n_p,

--- a/src/IO/lbsLoadReaderVT.py
+++ b/src/IO/lbsLoadReaderVT.py
@@ -83,9 +83,12 @@ class LoadReader:
         "NodeToCollectionBcast": 6,
     }
 
-    def __init__(self, file_prefix, verbose=False):
+    def __init__(self, file_prefix, verbose=False, file_suffix="vom"):
         # The base directory and file name for the log files
         self.file_prefix = file_prefix
+
+        # Data files(data loading) suffix
+        self.file_suffix = file_suffix
 
         # Enable or disable verbose mode
         self.verbose = verbose
@@ -94,8 +97,7 @@ class LoadReader:
         """Build the file name for a given rank/node ID
         """
 
-        return "{}.{}.vom".format(
-            self.file_prefix, node_id)
+        return f"{self.file_prefix}.{node_id}.{self.file_suffix}"
 
     def read(self, node_id, time_step=-1, comm=False):
         """Read the file for a given node/rank. If time_step==-1 then all

--- a/src/Model/lbsPhase.py
+++ b/src/Model/lbsPhase.py
@@ -61,7 +61,7 @@ class Phase:
     objects at a given round
     """
 
-    def __init__(self, t=0, verbose=False):
+    def __init__(self, t=0, verbose=False, file_suffix="vom"):
         # Initialize empty list of processors
         self.processors = []
 
@@ -77,6 +77,9 @@ class Phase:
         # Start with empty edges cache
         self.edges = {}
         self.cached_edges = False
+
+        # Data files suffix(reading from data)
+        self.file_suffix = file_suffix
 
     def get_processors(self):
         """Retrieve processors belonging to phase
@@ -347,7 +350,7 @@ class Phase:
         """
 
         # Instantiate VT load reader
-        reader = LoadReader(basename)
+        reader = LoadReader(basename, file_suffix=self.file_suffix)
 
         # Populate phase with reader output
         print(bcolors.HEADER


### PR DESCRIPTION
### THIS PR:
- added option `-j` for data reading file suffix
- defaulf file suffix is `.vom`
- file suffix needs to be given after `-j` E.g. `-j out` => then `*.out` file will be read instead of default `*.vom`

Closes #70