### PR TITLE
#82: Revamp the writer

### DIFF
--- a/src/Applications/LBAF.py
+++ b/src/Applications/LBAF.py
@@ -522,7 +522,7 @@ if __name__ == '__main__':
     # Instantiate phase to VT file writer if started from a log file
     if params.log_file:
         vt_writer = LoadWriterVT(phase, f"{output_stem}", output_dir=params.output_dir)
-        vt_writer.write(params.phase_id)
+        vt_writer.write()
 
     # If prefix parsed from command line
     if params.exodus:

--- a/src/IO/lbsLoadWriterVT.py
+++ b/src/IO/lbsLoadWriterVT.py
@@ -63,41 +63,37 @@ class LoadWriterVT:
     be mapped to that VT node for a given iteration/phase.
     """
 
-    def __init__(self, e, f="lbs_out", s="vom", output_dir=None):
+    def __init__(self, phase: Phase, f="lbs_out", s="vom", output_dir=None):
         """Class constructor:
-        e: Phase instance
+        phase: Phase instance
         f: file name stem
         s: suffix
         """
 
         # Ensure that provided phase has correct type
-        if not isinstance(e, Phase):
+        if not isinstance(phase, Phase):
             print(bcolors.ERR
                 + "*  ERROR: [LoadWriterExodusII] Could not write to ExodusII file by lack of a LBS phase"
                 + bcolors.END)
             return
 
         # Assign internals
-        self.phase = e
+        self.phase = phase
         self.file_stem = "{}".format(f)
         self.suffix = s
         self.output_dir = output_dir
 
-    def write(self, phase_id):
+    def write(self):
         """Write one CSV file per rank/procesor containing with one object
         per line, with the following format:
 
-            <source processor>, <object-id>, <time>
+            <phase-id>, <object-id>, <time>
         """
 
         # Iterate over processors
         for p in self.phase.processors:
             # Create file name for current processor
-            file_name = "{}.{}.{}.{}".format(
-                self.file_stem,
-                phase_id,
-                p.get_id(),
-                self.suffix)
+            file_name = f"{self.file_stem}.{p.get_id()}.{self.suffix}"
 
             if self.output_dir is not None:
                 file_name = os.path.join(self.output_dir, file_name)


### PR DESCRIPTION
THIS PR:
- changed epochs (e) to phases (p)
- removed `time step`(past) and `phase id`(current) from output file
- each record starts with `phase id`

resolve #82 