### PR TITLE
#141 create brute force optimizer for reference base cases

### DIFF
--- a/src/Applications/rank-object-enumerator.py
+++ b/src/Applications/rank-object-enumerator.py
@@ -1,0 +1,97 @@
+#@HEADER
+###############################################################################
+#
+#                          rank-object-enumerator.py
+#                           DARMA Toolkit v. 1.0.0
+#               DARMA/LB-analysis-framework => LB Analysis Framework
+#
+# Copyright 2021 National Technology & Engineering Solutions of Sandia, LLC
+# (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+# Government retains certain rights in this software.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from this
+#   software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Questions? Contact darma@sandia.gov
+#
+###############################################################################
+#@HEADER
+#
+###############################################################################
+import itertools
+
+# Dictionary of objects
+objects = (
+    {"id": 0, "time": 1.0},
+    {"id": 1, "time": 0.5},
+    {"id": 2, "time": 0.5},
+    {"id": 3, "time": 0.5},
+    {"id": 4, "time": 0.5},
+    {"id": 5, "time": 2.0},
+    {"id": 6, "time": 1.0},
+    {"id": 7, "time": 0.5},
+    {"id": 8, "time": 1.5})
+
+# Define number of ranks
+n_ranks = 4
+
+def compute_load(object_list):
+    # Load is sum of all object times
+    return sum([objects[i]["time"] for i in object_list])
+
+def compute_arrangement_works(arrangement, alpha, beta, gamma):
+    # Build object rank map from arrangement
+    ranks = {}
+    for i, j in enumerate(arrangement):
+        ranks.setdefault(j, []).append(i)
+
+    # Compute per-object loads
+    works = {}
+    for k, v in ranks.items():
+        works[k] = alpha * compute_load(v)
+
+    # Return computed works
+    return works
+
+if __name__ == '__main__':
+    initial_works = compute_arrangement_works((
+        0, 0, 0, 0, 1, 1, 1, 1, 2), 1., 0., 0.)
+    print("Initial work:", initial_works)
+    print("\tmaximum: {:.4g} average: {:.4g}".format(
+        max(initial_works.values()),
+        sum(initial_works.values()) / len(initial_works)))
+    
+    # Generate all possible arrangements with repetition
+    n_arrangements = 0
+    for v in itertools.product(range(n_ranks), repeat=len(objects)):
+        n_arrangements += 1
+        print(v)
+    rank_objects = {}
+    #for o in objects:
+        #for r in ranks:
+         #   rank_objects.setdefault(r, []).append(o)
+        #print(rank_arrangement, objects)
+    print(n_arrangements)

--- a/src/Applications/rank-object-enumerator.py
+++ b/src/Applications/rank-object-enumerator.py
@@ -41,6 +41,7 @@
 #@HEADER
 #
 ###############################################################################
+import math
 import itertools
 
 # Dictionary of objects
@@ -57,6 +58,11 @@ objects = (
 
 # Define number of ranks
 n_ranks = 4
+
+# Define work constants
+alpha = 1.
+beta = 0.
+gamma = 0.
 
 def compute_load(object_list):
     # Load is sum of all object times
@@ -77,8 +83,8 @@ def compute_arrangement_works(arrangement, alpha, beta, gamma):
     return works
 
 if __name__ == '__main__':
-    initial_works = compute_arrangement_works((
-        0, 0, 0, 0, 1, 1, 1, 1, 2), 1., 0., 0.)
+    initial_works = compute_arrangement_works(
+        (0, 0, 0, 0, 1, 1, 1, 1, 2), alpha, beta, gamma)
     print("Initial work:", initial_works)
     print("\tmaximum: {:.4g} average: {:.4g}".format(
         max(initial_works.values()),
@@ -86,12 +92,24 @@ if __name__ == '__main__':
     
     # Generate all possible arrangements with repetition
     n_arrangements = 0
-    for v in itertools.product(range(n_ranks), repeat=len(objects)):
+    works_min_max = math.inf
+    arrangements_min_max = []
+    for arrangement in itertools.product(range(n_ranks), repeat=len(objects)):
+        works = compute_arrangement_works(arrangement, alpha, beta, gamma)
+        work_max = max(works.values())
+        if work_max < works_min_max:
+            works_min_max = work_max
+            arrangements_min_max = [arrangement]
+        elif work_max == works_min_max:
+            arrangements_min_max.append(arrangement)
         n_arrangements += 1
-        print(v)
-    rank_objects = {}
-    #for o in objects:
-        #for r in ranks:
-         #   rank_objects.setdefault(r, []).append(o)
-        #print(rank_arrangement, objects)
-    print(n_arrangements)
+    print("Number of generated arrangements:", n_arrangements)
+    print("\tminimax work: {:.4g} for {} arrangements".format(
+        works_min_max,
+        len(arrangements_min_max)))
+    print("Example optimal arrangement:", arrangements_min_max[0])
+    optimal_works = compute_arrangement_works(
+        arrangements_min_max[0], alpha, beta, gamma)
+    print("\tmaximum: {:.4g} average: {:.4g}".format(
+        max(optimal_works.values()),
+        sum(optimal_works.values()) / len(optimal_works)))

--- a/src/Applications/rank-object-enumerator.py
+++ b/src/Applications/rank-object-enumerator.py
@@ -106,6 +106,11 @@ def compute_arrangement_works(arrangement, alpha, beta, gamma):
     return works
 
 if __name__ == '__main__':
+    # Print out input parameters
+    print("alpha:", alpha)
+    print("beta:", beta)
+    print("gamma:", gamma)
+
     # Report on some initial configuration
     initial_works = compute_arrangement_works(
         (0, 0, 0, 0, 1, 1, 1, 1, 2), alpha, beta, gamma)

--- a/src/Applications/rank-object-enumerator.py
+++ b/src/Applications/rank-object-enumerator.py
@@ -41,6 +41,7 @@
 #@HEADER
 #
 ###############################################################################
+import sys
 import math
 import itertools
 
@@ -83,10 +84,11 @@ def compute_arrangement_works(arrangement, alpha, beta, gamma):
     return works
 
 if __name__ == '__main__':
+    # Report on some initial configuration
     initial_works = compute_arrangement_works(
         (0, 0, 0, 0, 1, 1, 1, 1, 2), alpha, beta, gamma)
-    print("Initial work:", initial_works)
-    print("\tmaximum: {:.4g} average: {:.4g}".format(
+    print("Initial works:", initial_works)
+    print("\tmaximum work: {:.4g} average work: {:.4g}".format(
         max(initial_works.values()),
         sum(initial_works.values()) / len(initial_works)))
     
@@ -95,21 +97,33 @@ if __name__ == '__main__':
     works_min_max = math.inf
     arrangements_min_max = []
     for arrangement in itertools.product(range(n_ranks), repeat=len(objects)):
+        # Compute per-rank works for currrent arrangement
         works = compute_arrangement_works(arrangement, alpha, beta, gamma)
+
+        # Update minmax when relevant
         work_max = max(works.values())
         if work_max < works_min_max:
             works_min_max = work_max
             arrangements_min_max = [arrangement]
         elif work_max == works_min_max:
             arrangements_min_max.append(arrangement)
+
+        # Keep track of number of arrangements for sanity
         n_arrangements += 1
+
+    # Sanity check
     print("Number of generated arrangements:", n_arrangements)
+    if n_arrangements != n_ranks ** len(objects):
+        print("** ERROR: incorrect numnber of arrangements")
+        sys.exit(1)
+
+    # Report on optimal arrangements
     print("\tminimax work: {:.4g} for {} arrangements".format(
         works_min_max,
         len(arrangements_min_max)))
     print("Example optimal arrangement:", arrangements_min_max[0])
     optimal_works = compute_arrangement_works(
         arrangements_min_max[0], alpha, beta, gamma)
-    print("\tmaximum: {:.4g} average: {:.4g}".format(
+    print("\tmaximum work: {:.4g} average work: {:.4g}".format(
         max(optimal_works.values()),
         sum(optimal_works.values()) / len(optimal_works)))


### PR DESCRIPTION
Fixes #141 

It is working as expected, i.e., for "pure" load-balancing:
```
[pppebay@localhost]~/Documents/Git/LB-analysis-framework/src/Applications$ python rank-object-enumerator.py
alpha: 1.0
beta: 0.0
gamma: 0.0
Initial works: {0: 2.5, 1: 4.0, 2: 1.5}
	maximum work: 4 average work: 2.667
Number of generated arrangements: 262144
	minimax work: 2 for 840 arrangements
Example optimal arrangement: (0, 0, 0, 1, 1, 2, 1, 3, 3)
	maximum work: 2 average work: 2
```
or for "pure" communication volume minimization:
```
[pppebay@localhost]~/Documents/Git/LB-analysis-framework/src/Applications$ python rank-object-enumerator.py
alpha: 0.0
beta: 1.0
gamma: 0.0
Initial works: {0: 3.5, 1: 4.5, 2: 2.5}
	maximum work: 4.5 average work: 3.5
Number of generated arrangements: 262144
	minimax work: 0 for 16 arrangements
Example optimal arrangement: (0, 0, 0, 0, 0, 0, 0, 0, 0)
	maximum work: 0 average work: 0
[pppebay@localhost]~/Documents/Git/LB-analysis-framework/src/Applications$ python rank-object-enumerator.py
```
or for some arbitrary linear combination thereof:
```
alpha: 1.0
beta: 1.0
gamma: 0.0
Initial works: {0: 6.0, 1: 8.5, 2: 4.0}
	maximum work: 8.5 average work: 6.167
Number of generated arrangements: 262144
	minimax work: 4 for 24 arrangements
Example optimal arrangement: (0, 0, 1, 1, 0, 2, 1, 1, 3)
	maximum work: 4 average work: 4
```