### PR TITLE
#171: Have LBAF use a (new) output_file_stem variable for output files

### DIFF
--- a/src/Applications/LBAF.py
+++ b/src/Applications/LBAF.py
@@ -132,6 +132,9 @@ class internalParameters:
         # Output directory
         self.output_dir = None
 
+        # Output file steam
+        self.output_file_stem = None
+
         # Generate multimedia
         self.generate_multimedia = False
 
@@ -385,7 +388,10 @@ if __name__ == '__main__':
     grid_map = lambda x: global_id_to_cartesian(x.get_id(), params.grid_size)
 
     # Assemble output file name stem
-    output_stem = get_output_file_stem(params)
+    if params.output_file_stem is not None:
+        output_stem = params.output_file_stem
+    else:
+        output_stem = get_output_file_stem(params)
 
     # Instantiate phase to VT file writer if started from a log file
     if params.log_file:

--- a/src/Applications/conf.yaml
+++ b/src/Applications/conf.yaml
@@ -70,6 +70,7 @@ output_dir: "output"
 x_procs: 2
 y_procs: 2
 z_procs: 1
+output_file_stem: output_file
 
 # Simulate from samplers (comment out if reading from log)
 #n_objects: 200


### PR DESCRIPTION
### THIS PR:
- added `output_file_stem` key to the config file
- added support in LBAF for output file stem

close #171 