### PR TITLE
180 Make name of configuation file a mandatory parameter of LBAF

### DIFF
--- a/scripts/test_lbaf.py
+++ b/scripts/test_lbaf.py
@@ -48,6 +48,7 @@ def run_tests():
     imbalance_file = f"/lbaf/output/imbalance.txt"
     with open(imbalance_file, 'r') as imb_file:
         imb_level = float(imb_file.read())
+        print(f"@@@@@ FOUND IMBALANCE: {imb_level} @@@@@")
         if imb_level < 0.000001:
             print(f"===> TEST PASSED!")
         else:

--- a/src/Applications/LBAF.py
+++ b/src/Applications/LBAF.py
@@ -71,7 +71,7 @@ class internalParameters:
     """A class to describe LBAF internal parameters
     """
 
-    def __init__(self):
+    def __init__(self, config_file: str = None):
         # By default use load-only work model
         self.work_model = {"name": "LoadOnly", "parameters": {}}
 
@@ -149,7 +149,10 @@ class internalParameters:
 
         # Configuration file
         self.conf_file_found = False
-        self.conf = self.get_conf_file()
+        if config_file is None:
+            self.conf = self.get_conf_file()
+        else:
+            self.conf = self.get_conf_file(conf_file=config_file)
         if self.conf_file_found:
             self.parse_conf_file()
         self.checks_after_init()
@@ -329,7 +332,7 @@ def get_output_file_stem(params):
 
 if __name__ == '__main__':
     # Instantiate parameters
-    params = internalParameters()
+    params = internalParameters(config_file=os.path.join(project_path, "src", "Applications", "conf.yaml"))
 
     # Assign logger to variable
     lgr = params.logger

--- a/src/Applications/conf.yaml
+++ b/src/Applications/conf.yaml
@@ -49,7 +49,7 @@ work_model:
   name: AffineCombination
   parameters:
     alpha: 1.
-    beta: 1.
+    beta: 0.
     gamma: 0.
 
 # Specify transfer strategy

--- a/src/Applications/conf.yaml
+++ b/src/Applications/conf.yaml
@@ -48,7 +48,7 @@ fanout: 4
 work_model:
   name: AffineCombination
   parameters:
-    alpha: 0.
+    alpha: 1.
     beta: 1.
     gamma: 0.
 
@@ -58,7 +58,7 @@ criterion:
   name: Tempered
   parameters:
     actual_destination_load: True
-max_objects_per_transfer: 3
+max_objects_per_transfer: 8
 #deterministic_transfer: True
 
 # Specify number of simulation passes

--- a/src/Applications/conf.yaml
+++ b/src/Applications/conf.yaml
@@ -48,7 +48,7 @@ fanout: 4
 work_model:
   name: AffineCombination
   parameters:
-    alpha: 1.
+    alpha: 0.
     beta: 1.
     gamma: 0.
 
@@ -58,14 +58,14 @@ criterion:
   name: Tempered
   parameters:
     actual_destination_load: True
-max_objects_per_transfer: 8
+max_objects_per_transfer: 3
 #deterministic_transfer: True
 
 # Specify number of simulation passes
 n_iterations: 8
 
 # Specify output
-logging_level: debug
+logging_level: info
 terminal_background: light
 exodus: True
 output_dir: output


### PR DESCRIPTION
### THIS PR:

- added `config_file` as input parameter for `internalParameters` class

close #180 

@ppebay CI test is failing. I didn't make any changes which could make that happend. Config file is under `scripts/test_config.conf.yaml` please take a look. I also added print statement in test. It prints now found imbalance:
```shell
[LBAF] Process complete ###
@@@@@ FOUND IMBALANCE: 0.75 @@@@@
===> TEST FAILED!
```
