### PR TITLE
#204: make rank object enumerator usable in lbaf

### DIFF
--- a/scripts/test_config/conf.yaml
+++ b/scripts/test_config/conf.yaml
@@ -13,7 +13,7 @@ n_iterations: 8
 n_rounds: 4
 fanout: 4
 phase_id: 0
-log_file: "data/synthetic_lb_stats/stats"
+log_file: "data/synthetic_lb_data/data"
 file_suffix: json
 exodus: True
 x_procs: 2

--- a/src/IO/lbsVTDataReader.py
+++ b/src/IO/lbsVTDataReader.py
@@ -247,13 +247,10 @@ class LoadReader:
                 if phase_ids in (phase_id, -1):
                     # Instantiate object with retrieved parameters
                     obj = Object(task_object_id, task_time, node_id)
-
-                    # If this iteration was never encoutered initialize rank object
+                    # If this iteration was never encountered initialize rank object
                     returned_dict.setdefault(phase_id, Rank(node_id, logger=self.lgr))
-
                     # Add object to rank
                     returned_dict[phase_id].add_migratable_object(obj)
-
                     # Print debug information when requested
                     self.lgr.debug(f"Added object {task_object_id}, time = {task_time} to phase {phase_id}")
 

--- a/src/Model/lbsObject.py
+++ b/src/Model/lbsObject.py
@@ -77,12 +77,6 @@ class Object:
     def __repr__(self):
         return f"Object id: {self.index}, time: {self.time}"
 
-    def __eq__(self, other):
-        return hash(self) == hash(other)
-
-    def __hash__(self):
-        return hash(self.index) ^ hash(self.time)
-
     def get_id(self) -> int:
         """ Return object ID
         """

--- a/tests/test_lbs_vt_statistics_reader.py
+++ b/tests/test_lbs_vt_statistics_reader.py
@@ -50,12 +50,11 @@ class TestConfig(unittest.TestCase):
             {}
         ]
         self.ranks_iter_map = [{0: Rank(i=0, mo={Object(i=3, t=0.5), Object(i=2, t=0.5), Object(i=0, t=1.0),
-                                            Object(i=1, t=0.5)}, logger=self.logger)},
-                          {0: Rank(i=1, mo={Object(i=5, t=2.0), Object(i=7, t=0.5), Object(i=6, t=1.0),
-                                            Object(i=4, t=0.5)}, logger=self.logger)},
-                          {0: Rank(i=2, mo={Object(i=8, t=1.5)}, logger=self.logger)},
-                          {0: Rank(i=3, logger=self.logger)}
-                          ]
+                                                 Object(i=1, t=0.5)}, logger=self.logger)},
+                               {0: Rank(i=1, mo={Object(i=5, t=2.0), Object(i=7, t=0.5), Object(i=6, t=1.0),
+                                                 Object(i=4, t=0.5)}, logger=self.logger)},
+                               {0: Rank(i=2, mo={Object(i=8, t=1.5)}, logger=self.logger)},
+                               {0: Rank(i=3, logger=self.logger)}]
 
     def test_lbs_vt_statistics_reader_initialization(self):
         self.assertEqual(self.lr.file_prefix, self.file_prefix)
@@ -78,8 +77,14 @@ class TestConfig(unittest.TestCase):
         for phase in range(4):
             rank_iter_map, rank_comm = self.lr.read(phase, 0)
             self.assertEqual(self.ranks_comm[phase], rank_comm)
-            self.assertEqual(sorted(list(self.ranks_iter_map[phase].get(0).migratable_objects), key=lambda x: x.index),
-                             sorted(list(rank_iter_map.get(0).migratable_objects), key=lambda x: x.index))
+            prepared_list = sorted(list(self.ranks_iter_map[phase].get(0).migratable_objects), key=lambda x: x.index)
+            generated_list = sorted(list(rank_iter_map.get(0).migratable_objects), key=lambda x: x.index)
+            prep_time_list = [obj.get_time() for obj in prepared_list]
+            gen_time_list = [obj.get_time() for obj in generated_list]
+            prep_id_list = [obj.get_id() for obj in prepared_list]
+            gen_id_list = [obj.get_id() for obj in generated_list]
+            self.assertEqual(prep_time_list, gen_time_list)
+            self.assertEqual(prep_id_list, gen_id_list)
 
     def test_lbs_vt_statistics_reader_read_compressed(self):
         file_prefix = os.path.join(self.data_dir, 'synthetic_lb_stats_compressed', 'stats')
@@ -87,8 +92,14 @@ class TestConfig(unittest.TestCase):
         for phase in range(4):
             rank_iter_map, rank_comm = lr.read(phase, 0)
             self.assertEqual(self.ranks_comm[phase], rank_comm)
-            self.assertEqual(sorted(list(self.ranks_iter_map[phase].get(0).migratable_objects), key=lambda x: x.index),
-                             sorted(list(rank_iter_map.get(0).migratable_objects), key=lambda x: x.index))
+            prepared_list = sorted(list(self.ranks_iter_map[phase].get(0).migratable_objects), key=lambda x: x.index)
+            generated_list = sorted(list(rank_iter_map.get(0).migratable_objects), key=lambda x: x.index)
+            prep_time_list = [obj.get_time() for obj in prepared_list]
+            gen_time_list = [obj.get_time() for obj in generated_list]
+            prep_id_list = [obj.get_id() for obj in prepared_list]
+            gen_id_list = [obj.get_id() for obj in generated_list]
+            self.assertEqual(prep_time_list, gen_time_list)
+            self.assertEqual(prep_id_list, gen_id_list)
 
     def test_lbs_vt_statistics_reader_read_file_not_found(self):
         with self.assertRaises(FileNotFoundError) as err:
@@ -109,10 +120,14 @@ class TestConfig(unittest.TestCase):
             rank_iter_map, rank_comm = self.lr.json_reader(returned_dict={}, file_name=file_name, phase_ids=0,
                                                            node_id=phase)
             self.assertEqual(self.ranks_comm[phase], rank_comm)
-            self.assertEqual(sorted(list(self.ranks_iter_map[phase].get(0).migratable_objects), key=lambda x: x.index),
-                             sorted(list(rank_iter_map.get(0).migratable_objects), key=lambda x: x.index))
-
-
+            prepared_list = sorted(list(self.ranks_iter_map[phase].get(0).migratable_objects), key=lambda x: x.index)
+            generated_list = sorted(list(rank_iter_map.get(0).migratable_objects), key=lambda x: x.index)
+            prep_time_list = [obj.get_time() for obj in prepared_list]
+            gen_time_list = [obj.get_time() for obj in generated_list]
+            prep_id_list = [obj.get_id() for obj in prepared_list]
+            gen_id_list = [obj.get_id() for obj in generated_list]
+            self.assertEqual(prep_time_list, gen_time_list)
+            self.assertEqual(prep_id_list, gen_id_list)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### THIS PR:
- removed __hash__ and __eq__ from lbsObject
- fixed formatting and typos in lbsRuntime and lbsDataReader
- reorganized rank_object_enumerator, so it works in both data reader and simulation from samplers
- fixed failing tests because of the changes
- fixed location of the data for testing config

Closes #204 