### PR TITLE
#249: Gracefully exit from configuration validator

### DIFF
--- a/src/lbaf/Applications/LBAF_app.py
+++ b/src/lbaf/Applications/LBAF_app.py
@@ -160,8 +160,17 @@ class LBAFApp:
         self.logger = self.params.logger
 
         # Traceback setup
-        if self.params.show_traceback:
-            self.logger.info(f"Showing Traceback")
+        if "show_traceback" in self.params.__dict__:
+            if self.params.show_traceback:
+                self.logger.info(f"Showing Traceback")
+            else:
+                self.logger.info(f"Hiding Traceback")
+
+                def exception_handler(exception_type, exception, traceback):
+                    """ Exception handler for hiding traceback. """
+                    self.logger.error(f"{exception_type.__name__} {exception}")
+
+                sys.excepthook = exception_handler
         else:
             self.logger.info(f"Hiding Traceback")
             def exception_handler(exception_type, exception, traceback):

--- a/src/lbaf/Applications/LBAF_app.py
+++ b/src/lbaf/Applications/LBAF_app.py
@@ -53,6 +53,7 @@ class internalParameters:
             "output_dir",
             "output_file_stem",
             "terminal_background",
+            "show_traceback",
             "work_model"
         )
 
@@ -157,6 +158,17 @@ class LBAFApp:
 
         # Assign logger to variable
         self.logger = self.params.logger
+
+        # Traceback setup
+        if self.params.show_traceback:
+            self.logger.info(f"Showing Traceback")
+        else:
+            self.logger.info(f"Hiding Traceback")
+            def exception_handler(exception_type, exception, traceback):
+                """ Exception handler for hiding traceback. """
+                self.logger.error(f"{exception_type.__name__} {exception}")
+
+            sys.excepthook = exception_handler
 
     @staticmethod
     def __get_config_file() -> str:

--- a/src/lbaf/Applications/conf.yaml
+++ b/src/lbaf/Applications/conf.yaml
@@ -27,6 +27,7 @@
 # map_file [str]               base file name for VT object/proc mapping
 # file_suffix [str]            file suffix of VT data files (default: "json")
 # output_dir [str]             output directory (default: '.')
+# show_traceback [bool]        show traceback (default: False)
 # terminal_background [str]    background color for terminal output
 # generate_meshes [bool]       generate mesh outputs (default: False)
 # generate_multimedia [bool]   generate multimedia visualization (default: False)
@@ -69,6 +70,7 @@ algorithm:
 
 # Specify output
 #logging_level: debug
+show_traceback: False
 terminal_background: light
 generate_multimedia: False
 output_dir: ../../../output

--- a/src/lbaf/IO/configurationValidator.py
+++ b/src/lbaf/IO/configurationValidator.py
@@ -69,6 +69,7 @@ class ConfigurationValidator:
                     error="Should be of type 'float' and magnitude < 1")
                 },
             Optional("brute_force_optimization"): bool,
+            Optional("show_traceback"): bool,
             Optional("logging_level"): And(
                 str, Use(str.lower),
                 lambda f: f in ALLOWED_LOGGING_LEVELS,

--- a/src/lbaf/IO/configurationValidator.py
+++ b/src/lbaf/IO/configurationValidator.py
@@ -1,5 +1,6 @@
 from collections import Iterable
 from logging import Logger
+import sys
 
 from schema import And, Optional, Or, Schema, Use
 
@@ -142,9 +143,14 @@ class ConfigurationValidator:
         is_valid = valid_schema.is_valid(schema_to_validate)
         return is_valid
 
-    @staticmethod
-    def validate(valid_schema: Schema, schema_to_validate: dict):
+    def validate(self, valid_schema: Schema, schema_to_validate: dict):
         """ Return validated schema. """
+
+        def exception_handler(exception_type, exception, traceback):
+            """ Exception handler for hiding traceback. """
+            self.__logger.error(f"{exception_type.__name__} {exception}")
+
+        sys.excepthook = exception_handler
         return valid_schema.validate(schema_to_validate)
 
     def main(self):

--- a/src/lbaf/IO/schemaValidator.py
+++ b/src/lbaf/IO/schemaValidator.py
@@ -1,4 +1,5 @@
 from collections import Iterable
+import sys
 
 from schema import And, Optional, Schema
 
@@ -264,5 +265,11 @@ class SchemaValidator:
         return is_valid
 
     def validate(self, schema_to_validate: dict):
-        """ Returns validated schema. """
+        """ Return validated schema. """
+
+        def exception_handler(exception_type, exception, traceback):
+            """ Exception handler for hiding traceback. """
+            self.__logger.error(f"{exception_type.__name__} {exception}")
+
+        sys.excepthook = exception_handler
         return self.valid_schema.validate(schema_to_validate)


### PR DESCRIPTION
### THIS PR:

- removed traceback when use `schema` library 
- added show_traceback to configuration file (default False)
- added `show_traceback` to configuration validator as optional
- added traceback setup to the LBAF init

Closes #249 