### PR TITLE
#272: Remove show_traceback option from configuration

### DIFF
--- a/src/lbaf/Applications/LBAF_app.py
+++ b/src/lbaf/Applications/LBAF_app.py
@@ -55,7 +55,6 @@ class internalParameters:
             "output_dir",
             "output_file_stem",
             "terminal_background",
-            "show_traceback",
             "work_model"
         )
 
@@ -163,26 +162,6 @@ class LBAFApp:
 
         # Assign logger to variable
         self.logger = self.params.logger
-
-        # Traceback setup
-        if "show_traceback" in self.params.__dict__:
-            if self.params.show_traceback:
-                self.logger.info(f"Showing Traceback")
-            else:
-                self.logger.info(f"Hiding Traceback")
-
-                def exception_handler(exception_type, exception, traceback):
-                    """ Exception handler for hiding traceback. """
-                    self.logger.error(f"{exception_type.__name__} {exception}")
-
-                sys.excepthook = exception_handler
-        else:
-            self.logger.info(f"Hiding Traceback")
-            def exception_handler(exception_type, exception, traceback):
-                """ Exception handler for hiding traceback. """
-                self.logger.error(f"{exception_type.__name__} {exception}")
-
-            sys.excepthook = exception_handler
 
     @staticmethod
     def __get_config_file() -> str:

--- a/src/lbaf/Applications/conf.yaml
+++ b/src/lbaf/Applications/conf.yaml
@@ -29,7 +29,6 @@
 # map_file [str]               base file name for VT object/proc mapping
 # file_suffix [str]            file suffix of VT data files (default: "json")
 # output_dir [str]             output directory (default: '.')
-# show_traceback [bool]        show traceback (default: False)
 # terminal_background [str]    background color for terminal output
 # generate_meshes [bool]       generate mesh outputs (default: False)
 # generate_multimedia [bool]   generate multimedia visualization (default: False)
@@ -72,7 +71,6 @@ algorithm:
 
 # Specify output
 #logging_level: debug
-show_traceback: True
 terminal_background: light
 generate_multimedia: False
 output_dir: ../../../output

--- a/src/lbaf/IO/configurationValidator.py
+++ b/src/lbaf/IO/configurationValidator.py
@@ -3,6 +3,7 @@ from logging import Logger
 import sys
 
 from schema import And, Optional, Or, Schema, Use
+from ..Utils.exception_handler import exc_handler
 
 
 # Allowed configuration values
@@ -72,7 +73,6 @@ class ConfigurationValidator:
                     error="Should be of type 'float' and magnitude < 1")
                 },
             Optional("brute_force_optimization"): bool,
-            Optional("show_traceback"): bool,
             Optional("log_to_file"): str,
             Optional("logging_level"): And(
                 str, Use(str.lower),
@@ -149,14 +149,10 @@ class ConfigurationValidator:
         is_valid = valid_schema.is_valid(schema_to_validate)
         return is_valid
 
-    def validate(self, valid_schema: Schema, schema_to_validate: dict):
+    @staticmethod
+    def validate(valid_schema: Schema, schema_to_validate: dict):
         """ Return validated schema. """
-
-        def exception_handler(exception_type, exception, traceback):
-            """ Exception handler for hiding traceback. """
-            self.__logger.error(f"{exception_type.__name__} {exception}")
-
-        sys.excepthook = exception_handler
+        sys.excepthook = exc_handler
         return valid_schema.validate(schema_to_validate)
 
     def main(self):

--- a/src/lbaf/IO/schemaValidator.py
+++ b/src/lbaf/IO/schemaValidator.py
@@ -268,10 +268,5 @@ class SchemaValidator:
 
     def validate(self, schema_to_validate: dict):
         """ Return validated schema. """
-
-        def exception_handler(exception_type, exception, traceback):
-            """ Exception handler for hiding traceback. """
-            self.__logger.error(f"{exception_type.__name__} {exception}")
-
-        sys.excepthook = exception_handler
+        sys.excepthook = exc_handler
         return self.valid_schema.validate(schema_to_validate)

--- a/src/lbaf/Model/lbsPhase.py
+++ b/src/lbaf/Model/lbsPhase.py
@@ -1,5 +1,6 @@
 from logging import Logger
 import random as rnd
+import sys
 
 from .lbsObject import Object
 from .lbsRank import Rank


### PR DESCRIPTION
### THIS PR:
- removed `show_traceback` from conf.yaml
- removed `show_traceback` and exception_handler from configurationValidator.py
- removed `show_traceback` from LBAF
- added `import sys` as it was missing in lbsPhase.py
- changed method responsible for handling exceptions in schemaValidator.py

closes #272 