### PR TITLE
#269: added printing and calculating statistics from sub-phases

### DIFF
--- a/src/lbaf/Applications/LBAF_app.py
+++ b/src/lbaf/Applications/LBAF_app.py
@@ -215,6 +215,11 @@ class LBAFApp:
             "initial rank loads",
             self.logger)
         lbstats.print_function_statistics(
+            phase_0.get_ranks(),
+            lambda x: x.get_load_subphases(),
+            "initial rank loads from sub-phases",
+            self.logger)
+        lbstats.print_function_statistics(
             phase_0.get_edges().values(),
             lambda x: x,
             "initial sent volumes",
@@ -301,6 +306,11 @@ class LBAFApp:
             file_name=("imbalance.txt"
                        if self.params.output_dir is None
                        else os.path.join(self.params.output_dir, "imbalance.txt")))
+        _, _, l_ave, _, _, _, _, _ = lbstats.print_function_statistics(
+            phase_0.get_ranks(),
+            lambda x: x.get_load(),
+            "final rank loads from sub-phases",
+            self.logger)
         lbstats.print_function_statistics(
             phase_0.get_edges().values(),
             lambda x: x,

--- a/src/lbaf/Execution/lbsInformAndTransferAlgorithm.py
+++ b/src/lbaf/Execution/lbsInformAndTransferAlgorithm.py
@@ -335,6 +335,11 @@ class InformAndTransferAlgorithm(AlgorithmBase):
                 lambda x: self.work_model.compute(x),
                 f"iteration {i + 1} rank works",
                 self.__logger)
+            n_w, w_min, w_ave, w_max, w_var, _, _, _ = print_function_statistics(
+                self.phase.get_ranks(),
+                lambda x: self.work_model.compute_subphases(x),
+                f"iteration {i + 1} rank works from sub-phases",
+                self.__logger)
 
             # Update run distributions and statistics
             self.update_distributions_and_statistics(distributions, statistics)

--- a/src/lbaf/Execution/lbsPhaseStepperAlgorithm.py
+++ b/src/lbaf/Execution/lbsPhaseStepperAlgorithm.py
@@ -47,6 +47,11 @@ class PhaseStepperAlgorithm(AlgorithmBase):
                 lambda x: self.work_model.compute(x),
                 f"iteration {i + 1} rank works",
                 self.__logger)
+            n_w, w_min, w_ave, w_max, w_var, _, _, _ = print_function_statistics(
+                self.phase.get_ranks(),
+                lambda x: self.work_model.compute_subphases(x),
+                f"iteration {i + 1} rank works from sub-phases",
+                self.__logger)
 
             # Update run distributions and statistics
             self.update_distributions_and_statistics(distributions, statistics)

--- a/src/lbaf/Model/lbsAffineCombinationWorkModel.py
+++ b/src/lbaf/Model/lbsAffineCombinationWorkModel.py
@@ -34,6 +34,15 @@ class AffineCombinationWorkModel(WorkModelBase):
             rank.get_received_volume(),
             rank.get_sent_volume()) + self.__gamma
 
+    def compute_subphases(self, rank: Rank):
+        """ A work model with affine combination of load from sub-phases and communication
+            alpha * load from sub-phases + beta * max(sent, received) + gamma
+        """
+        # Compute affine combination of load and volumes
+        return self.__alpha * rank.get_load_subphases() + self.__beta * max(
+            rank.get_received_volume(),
+            rank.get_sent_volume()) + self.__gamma
+
     def aggregate(self, values: dict):
         """ A work model with affine combination of load and communication
             alpha * load + beta * max(sent, received) + gamma

--- a/src/lbaf/Model/lbsLoadOnlyWorkModel.py
+++ b/src/lbaf/Model/lbsLoadOnlyWorkModel.py
@@ -26,6 +26,12 @@ class LoadOnlyWorkModel(WorkModelBase):
         # Return total load on this rank
         return rank.get_load()
 
+    def compute_subphases(self, rank: Rank):
+        """ A work model summing all object times from sub-phases on given rank
+        """
+        # Return total load on this rank
+        return rank.get_load_subphases()
+
     def aggregate(self, values: dict):
         """ A work model only using load information
         """

--- a/src/lbaf/Model/lbsObject.py
+++ b/src/lbaf/Model/lbsObject.py
@@ -115,3 +115,10 @@ class Object:
         """ Return subphases of this object
         """
         return self.__subphases
+
+    def get_subphases_time(self) -> float:
+        """ Return sub-phases time
+        """
+        if self.__subphases is None:
+            return 0.0
+        return sum([subphase.get('time') for subphase in self.__subphases])

--- a/src/lbaf/Model/lbsPhase.py
+++ b/src/lbaf/Model/lbsPhase.py
@@ -248,6 +248,7 @@ class Phase:
         for p in self.__ranks:
             objects = objects.union(p.get_objects())
         print_function_statistics(objects, lambda x: x.get_time(), "object times", self.__logger)
+        print_function_statistics(objects, lambda x: x.get_subphases_time(), "object's sub-phases times", self.__logger)
 
         # Set number of read objects
         self.__n_objects = len(objects)

--- a/src/lbaf/Model/lbsRank.py
+++ b/src/lbaf/Model/lbsRank.py
@@ -77,7 +77,7 @@ class Rank:
         """ Return IDs of sentinel objects assigned to rank."""
         return [o.get_id() for o in self.__sentinel_objects]
 
-    def is_sentinel(self, o: Object) -> list:
+    def is_sentinel(self, o: Object) -> bool:
         """ Return whether object is a sentinel or not."""
         if o in self.__sentinel_objects:
             return True
@@ -111,13 +111,25 @@ class Rank:
         """ Return total load on rank."""
         return sum([o.get_time() for o in self.__migratable_objects.union(self.__sentinel_objects)])
 
+    def get_load_subphases(self) -> float:
+        """ Return total load on rank from sub-phases."""
+        return sum([o.get_subphases_time() for o in self.__migratable_objects.union(self.__sentinel_objects)])
+
     def get_migratable_load(self) -> float:
         """ Return migratable load on rank."""
         return sum([o.get_time() for o in self.__migratable_objects])
 
+    def get_migratable_load_subphases(self) -> float:
+        """ Return migratable load on rank from sub-phases."""
+        return sum([o.get_subphases_time() for o in self.__migratable_objects])
+
     def get_sentinel_load(self) -> float:
         """ Return sentinel load oon rank."""
         return sum([o.get_time() for o in self.__sentinel_objects])
+
+    def get_sentinel_load_subphases(self) -> float:
+        """ Return sentinel load oon rank from sub-phases."""
+        return sum([o.get_subphases_time() for o in self.__sentinel_objects])
 
     def get_received_volume(self):
         """ Return volume received by objects assigned to rank from other ranks."""

--- a/src/lbaf/Model/lbsWorkModelBase.py
+++ b/src/lbaf/Model/lbsWorkModelBase.py
@@ -47,6 +47,12 @@ class WorkModelBase:
         # Must be implemented by concrete subclass
 
     @abc.abstractmethod
+    def compute_subphases(self, rank):
+        """ Return value of work for given rank
+        """
+        # Must be implemented by concrete subclass
+
+    @abc.abstractmethod
     def aggregate(self, values: dict):
         """ Return value of work given relevant dictionary of values
         """


### PR DESCRIPTION
- added get_load from sub-phases in Rank
- added compute_subphases to work models
- added printing statistics from sub-phases in algorithms and main LBAF routine
- added get_subphases_time to object
- added printing statistics from sub-phases when populating from log
- fixed returned type for is_sentinel in Rank

closes #269 