### PR TITLE
#277: Accept range in phase indices in lbaf config

### DIFF
--- a/src/lbaf/Applications/LBAF_app.py
+++ b/src/lbaf/Applications/LBAF_app.py
@@ -112,7 +112,10 @@ class internalParameters:
         # Parse data parameters if present
         if self.configuration.get("from_data") is not None:
             self.data_stem = self.configuration.get("from_data").get("data_stem")
-            self.phase_ids = self.configuration.get("from_data").get("phase_ids")
+            if isinstance(self.configuration.get("from_data").get("phase_ids"), str):
+                self.phase_ids = list(map(int, self.configuration.get("from_data").get("phase_ids").split('-')))
+            else:
+                self.phase_ids = self.configuration.get("from_data").get("phase_ids")
 
         # Parse sampling parameters if present
         if self.configuration.get("from_samplers") is not None:

--- a/src/lbaf/Applications/LBAF_app.py
+++ b/src/lbaf/Applications/LBAF_app.py
@@ -113,7 +113,8 @@ class internalParameters:
         if self.configuration.get("from_data") is not None:
             self.data_stem = self.configuration.get("from_data").get("data_stem")
             if isinstance(self.configuration.get("from_data").get("phase_ids"), str):
-                self.phase_ids = list(map(int, self.configuration.get("from_data").get("phase_ids").split('-')))
+                range_list = list(map(int, self.configuration.get("from_data").get("phase_ids").split('-')))
+                self.phase_ids = list(range(range_list[0], range_list[1] + 1))
             else:
                 self.phase_ids = self.configuration.get("from_data").get("phase_ids")
 

--- a/src/lbaf/Applications/conf.yaml
+++ b/src/lbaf/Applications/conf.yaml
@@ -25,7 +25,7 @@
 # y_procs [int]                number of procs in y direction for rank visualization
 # z_procs [int]                number of procs in z direction for rank visualization
 # data_stem [str]              base file name of VT load logs
-# phase_ids [list]             list of ids of phase to be read in VT load logs
+# phase_ids [list or str]      list of ids of phase to be read in VT load logs e.g. [1, 2, 3] or "1-3"
 # map_file [str]               base file name for VT object/proc mapping
 # file_suffix [str]            file suffix of VT data files (default: "json")
 # output_dir [str]             output directory (default: '.')

--- a/src/lbaf/IO/configurationValidator.py
+++ b/src/lbaf/IO/configurationValidator.py
@@ -2,7 +2,7 @@ from collections import Iterable
 from logging import Logger
 import sys
 
-from schema import And, Optional, Or, Schema, Use
+from schema import And, Optional, Or, Regex, Schema, Use
 from ..Utils.exception_handler import exc_handler
 
 
@@ -89,8 +89,11 @@ class ConfigurationValidator:
         })
         self.__from_data = Schema(
             {"data_stem": str,
-             "phase_ids": And(list, lambda x: all([isinstance(y, int) for y in x]),
-                              error="Should be of type 'list' of 'int' types")})
+             "phase_ids": Or(
+                 And(list, lambda x: all([isinstance(y, int) for y in x]),
+                     error="Should be of type 'list' of 'int' types"),
+                 Regex(r"^[0-9]+-[0-9]+$", error="Should be of type 'str' like '0-100'"))
+             })
         self.__from_samplers = Schema({
             "n_objects": And(int, lambda x: x > 0,
                              error="Should be of type 'int' and > 0"),

--- a/tests/data/config/conf_correct_phase_ids_str_001.yml
+++ b/tests/data/config/conf_correct_phase_ids_str_001.yml
@@ -1,0 +1,36 @@
+# Specify input
+from_data:
+  data_stem: "../data/synthetic_lb_data/data"
+  phase_ids: "0-3"
+
+# Specify work model
+work_model:
+  name: AffineCombination
+  parameters:
+    alpha: 1.
+    beta: 0.
+    gamma: 0.
+
+# Specify balancing algorithm
+algorithm:
+  name: InformAndTransfer
+  parameters:
+    n_iterations: 8
+    n_rounds: 4
+    fanout: 4
+    order_strategy: element_id
+    criterion: Tempered
+    max_objects_per_transfer: 8
+    deterministic_transfer: True
+
+# Specify output
+n_ranks: 4
+terminal_background: light
+generate_multimedia: False
+output_dir: ../../../output
+output_file_stem: output_file
+generate_meshes:
+  x_ranks: 2
+  y_ranks: 2
+  z_ranks: 1
+  object_jitter: 0.5

--- a/tests/data/config/conf_wrong_phase_ids_str_001.yml
+++ b/tests/data/config/conf_wrong_phase_ids_str_001.yml
@@ -1,0 +1,36 @@
+# Specify input
+from_data:
+  data_stem: "../data/synthetic_lb_data/data"
+  phase_ids: "0-3r"
+
+# Specify work model
+work_model:
+  name: AffineCombination
+  parameters:
+    alpha: 1.
+    beta: 0.
+    gamma: 0.
+
+# Specify balancing algorithm
+algorithm:
+  name: InformAndTransfer
+  parameters:
+    n_iterations: 8
+    n_rounds: 4
+    fanout: 4
+    order_strategy: element_id
+    criterion: Tempered
+    max_objects_per_transfer: 8
+    deterministic_transfer: True
+
+# Specify output
+n_ranks: 4
+terminal_background: light
+generate_multimedia: False
+output_dir: ../../../output
+output_file_stem: output_file
+generate_meshes:
+  x_ranks: 2
+  y_ranks: 2
+  z_ranks: 1
+  object_jitter: 0.5

--- a/tests/test_configuration_validator.py
+++ b/tests/test_configuration_validator.py
@@ -78,7 +78,7 @@ class TestConfig(unittest.TestCase):
 
         with self.assertRaises(SchemaError) as err:
             ConfigurationValidator(config_to_validate=configuration, logger=logger()).main()
-        self.assertEqual(err.exception.args[0], "Should be of type 'list' of 'int' types")
+        self.assertEqual(err.exception.args[0], "Should be of type 'list' of 'int' types\nShould be of type 'str' like '0-100'")
 
     def test_config_validator_wrong_from_data_phase_name(self):
         with open(os.path.join(self.config_dir, 'conf_wrong_from_data_phase_name.yml'), 'rt') as config_file:

--- a/tests/test_configuration_validator.py
+++ b/tests/test_configuration_validator.py
@@ -203,6 +203,20 @@ class TestConfig(unittest.TestCase):
             ConfigurationValidator(config_to_validate=configuration, logger=logger()).main()
         self.assertEqual(err.exception.args[0], "Key 'parameters' error:\nMissing key: 'fanout'")
 
+    def test_config_validator_correct_phase_ids_str_001(self):
+        with open(os.path.join(self.config_dir, 'conf_correct_phase_ids_str_001.yml'), 'rt') as config_file:
+            yaml_str = config_file.read()
+            configuration = yaml.safe_load(yaml_str)
+        ConfigurationValidator(config_to_validate=configuration, logger=logger()).main()
+
+    def test_config_validator_wrong_phase_ids_str_001(self):
+        with open(os.path.join(self.config_dir, 'conf_wrong_phase_ids_str_001.yml'), 'rt') as config_file:
+            yaml_str = config_file.read()
+            configuration = yaml.safe_load(yaml_str)
+        with self.assertRaises(SchemaError) as err:
+            ConfigurationValidator(config_to_validate=configuration, logger=logger()).main()
+        self.assertEqual(err.exception.args[0], "Should be of type 'list' of 'int' types\nShould be of type 'str' like '0-100'")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### THIS PR:
- added info in conf.yaml
- added tests of enhanced configuration option with two sample configurations
- modified parsing data parameters in LBAF_app
- modified configurationValidator.py, so it accepts str and validates it with Regex

closes #277 