### PR TITLE
#287: allow for a default 0-value of the jitter

### DIFF
--- a/src/lbaf/IO/lbsMeshBasedVisualizer.py
+++ b/src/lbaf/IO/lbsMeshBasedVisualizer.py
@@ -270,7 +270,9 @@ class MeshBasedVisualizer:
                 # Insert point using offset and rank coordinates
                 points.SetPoint(point_index, [
                     offsets[d] - centering[d] + (
-                        self.__jitter_dims[o.get_id()][d] + c) * o_resolution
+                        self.__jitter_dims.get(
+                            o.get_id(),
+                            (0.0, 0.0, 0.0))[d] + c) * o_resolution
                     for d, c in enumerate(self.global_id_to_cartesian(
                         i, rank_size))])
                 time = o.get_time()


### PR DESCRIPTION
fixes #287 

This is only a short-term fix, allowing for the visualization of data sets with variable number of objects across phases. It will only make sense if the jitter value is set to 0 globally.