### PR TITLE
#281: "time" key must be replaced with "load" for objects in JSON files

### DIFF
--- a/src/lbaf/IO/lbsVTDataWriter.py
+++ b/src/lbaf/IO/lbsVTDataWriter.py
@@ -37,9 +37,7 @@ class VTDataWriter:
         self.__output_dir = output_dir
 
     def write(self):
-        """ Write one JSON file per rank with the following format:
-            <phase-id>, <object-id>, <time>
-        """
+        """ Write one JSON file per rank. """
         sys.setrecursionlimit(25000)
         with Pool() as pool:
             results = pool.imap_unordered(self.json_writer, self.__phase.get_ranks())
@@ -82,7 +80,7 @@ class VTDataWriter:
             phase_dict = {"tasks": list(), "id": rank_id}
             for task in others_list:
                 task_dict = {
-                    "time": task["obj_time"],
+                    "load": task["obj_time"],
                     "resource": "cpu",
                     "object": task["obj_id"]}
                 phase_dict["tasks"].append(task_dict)

--- a/tests/test_vt_data_extractor.py
+++ b/tests/test_vt_data_extractor.py
@@ -260,8 +260,11 @@ class TestVTDataExtractor(unittest.TestCase):
             VTDataExtractor(input_data_dir=input_dir, output_data_dir=output_data_dir, phases_to_extract=phases,
                             file_prefix="data", file_suffix="json", compressed=False, schema_type="LBDatafile",
                             check_schema=False).main()
-        self.assertEqual(err.exception.args[0], f"Values in filenames can not be converted to `int`.\nPhases are not "
-                                                f"sorted.\nERROR: invalid literal for int() with base 10: 'other'")
+        expected = ["Values in filenames can not be converted to `int`.\nPhases are not sorted.\nERROR: invalid litera"
+                    "l for int() with base 10: 'other'",
+                    "Values in filenames can not be converted to `int`.\nPhases are not sorted.\nERROR: invalid litera"
+                    "l for int() with base 10: 'sm'"]
+        self.assertIn(err.exception.args[0], expected)
 
     def test_vt_data_extractor_015(self):
         phases = [0, 1]


### PR DESCRIPTION
### THIS PR:
- change time with load in VTDataWriter

Output from our `synthetic data`:
```Python3
{"phases":[{"tasks":[{"load":0.5,"resource":"cpu","object":7},{"load":1.0,"resource":"cpu","object":0},{"load":0.5,"resource":"cpu","object":4}],"id":0}]}
{"phases":[{"tasks":[{"load":2.0,"resource":"cpu","object":5}],"id":1}]}
{"phases":[{"tasks":[{"load":0.5,"resource":"cpu","object":2},{"load":1.5,"resource":"cpu","object":8}],"id":2}]}
{"phases":[{"tasks":[{"load":0.5,"resource":"cpu","object":3},{"load":1.0,"resource":"cpu","object":6},{"load":0.5,"resource":"cpu","object":1}],"id":3}]}
```

closes #281 