### PR TITLE
#308: setdefault dict method caused non used Rank instantiation

### DIFF
--- a/src/lbaf/IO/lbsVTDataReader.py
+++ b/src/lbaf/IO/lbsVTDataReader.py
@@ -228,7 +228,8 @@ class LoadReader:
                     obj = Object(task_object_id, task_time, node_id, user_defined=task_used_defined,
                                  subphases=subphases)
                     # If this iteration was never encountered initialize rank object
-                    returned_dict.setdefault(phase_id, Rank(node_id, logger=self.__logger))
+                    if returned_dict.get(phase_id) is None:
+                        returned_dict[phase_id] = Rank(node_id, logger=self.__logger)
                     # Add object to rank given its type
                     if entity.get("migratable"):
                         returned_dict[phase_id].add_migratable_object(obj)


### PR DESCRIPTION
### THIS PR:
- made Rank instantiation explicit

#### Before:
- after added below to Rank `__init__()`
```Python3
        print(f"@@@ {self.__index}")
        print(f"@@@@@ {id(self)}")
```
- the output only from `0` Rank (for Ranks 1-31 it is similar):
```bash
@@@ 0
@@@@@ 139700003736880
@@@ 0
@@@@@ 139700003507600
@@@ 0
@@@@@ 139700003504912
@@@ 0
@@@@@ 139700003507504
@@@ 0
@@@@@ 139700003505296
@@@ 0
@@@@@ 139700003505776
@@@ 0
@@@@@ 139700003507408
@@@ 0
@@@@@ 139700003505680
@@@ 0
@@@@@ 139700003505872
@@@ 0
@@@@@ 139700003535312
@@@ 0
@@@@@ 139700003535024
@@@ 0
@@@@@ 139700003535168
@@@ 0
@@@@@ 139700003535264
@@@ 0
@@@@@ 139700003534880
@@@ 0
@@@@@ 139700003534688
``` 

#### After applied fix:
- the output from all Ranks instantiation:
```bash
@@@ 0
@@@@@ 139796822948976
@@@ 1
@@@@@ 139796822751456
@@@ 2
@@@@@ 139796822751984
@@@ 3
@@@@@ 139796822801280
@@@ 4
@@@@@ 139796822800128
@@@ 5
@@@@@ 139796822798448
@@@ 6
@@@@@ 139796822799408
@@@ 7
@@@@@ 139796660835568
@@@ 8
@@@@@ 139796660836336
@@@ 9
@@@@@ 139796660837104
@@@ 10
@@@@@ 139796660837872
@@@ 11
@@@@@ 139796657226032
@@@ 12
@@@@@ 139796657226800
@@@ 13
@@@@@ 139796657227568
@@@ 14
@@@@@ 139796657228336
@@@ 15
@@@@@ 139796657229104
@@@ 16
@@@@@ 139796657066096
@@@ 17
@@@@@ 139796657066864
@@@ 18
@@@@@ 139796657067632
@@@ 19
@@@@@ 139796657068400
@@@ 20
@@@@@ 139796657069168
@@@ 21
@@@@@ 139796657069936
@@@ 22
@@@@@ 139796656587440
@@@ 23
@@@@@ 139796656588208
@@@ 24
@@@@@ 139796656588976
@@@ 25
@@@@@ 139796656589744
@@@ 26
@@@@@ 139796656590512
@@@ 27
@@@@@ 139796656271856
@@@ 28
@@@@@ 139796656272624
@@@ 29
@@@@@ 139796656273392
@@@ 30
@@@@@ 139796656274160
@@@ 31
@@@@@ 139796656274928
``` 
- each Rank is only instantiated once

closes #308 