### PR TITLE
#347: Fix terminal background in configuration file

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,8 +5,18 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "lbaf:run",
+            "name": "lbaf:run (Python3.8)",
             "python": "${workspaceFolder}/venv/bin/python",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/src/lbaf/__init__.py",
+            "console": "integratedTerminal",
+            "justMyCode": true,
+            "args": [ "--configuration", "conf.yaml"  ]
+        },
+        {
+            "name": "lbaf:run (Python3.9)",
+            "python": "${workspaceFolder}/venv39/bin/python",
             "type": "python",
             "request": "launch",
             "program": "${workspaceFolder}/src/lbaf/__init__.py",

--- a/config/acceptance_tests/conf.yaml
+++ b/config/acceptance_tests/conf.yaml
@@ -13,7 +13,7 @@ work_model:
     gamma: 0.0
 
 # Specify algorithm
-brute_force_optimization: true
+brute_force_optimization: True
 algorithm:
   name: InformAndTransfer
   phase_id: 0
@@ -25,7 +25,7 @@ algorithm:
     transfer_strategy: Recursive
     criterion: Tempered
     max_objects_per_transfer: 8
-    deterministic_transfer: true
+    deterministic_transfer: True
 
 # Specify output
 logging_level: info

--- a/config/challenging-toy-hundreds-tasks.yaml
+++ b/config/challenging-toy-hundreds-tasks.yaml
@@ -3,7 +3,7 @@ from_data:
   data_stem: ../data/challenging_toy_hundreds_tasks/toy
   phase_ids:
     - 0
-check_schema: false
+check_schema: False
 
 # Specify work model
 work_model:
@@ -27,10 +27,9 @@ algorithm:
     transfer_strategy: Clustering
     criterion: Tempered
     max_objects_per_transfer: 500
-    deterministic_transfer: false
+    deterministic_transfer: False
 
 # Specify output
-terminal_background: light
 output_dir: ../output
 output_file_stem: output_file
 n_ranks: 64
@@ -40,5 +39,5 @@ LBAF_Viz:
   z_ranks: 1
   object_jitter: 0.5
   rank_qoi: load
-  save_meshes: false
-  force_continuous_object_qoi: true
+  save_meshes: False
+  force_continuous_object_qoi: True

--- a/config/conf.yaml
+++ b/config/conf.yaml
@@ -1,6 +1,20 @@
 # Docs
 # parameter_name [type]        description
 # ---------------------------  -----------------------------------------------------------------------
+# from_data:
+#   data_stem: [str]           base file name of VT load logs
+#   phase_ids: [list or str]   list of ids of phase to be read in VT load logs e.g. [1, 2, 3] or "1-3"
+# from_samplers:
+#   n_objects [int]            number of objects
+#   n_mapped_ranks [int]       number of initially mapped processors
+#   communication_degree [int] object communication degree (no communication if 0)
+#   load_sampler               description of object load sampler:
+#     name [str]               in uniform, lognormal
+#     parameters [list]        parameters e.g. 1.0,10.0 for lognormal
+#   volume_sampler             description of object communication volumes sampler:
+#     name [str]               in uniform, lognormal
+#     parameters [list]        parameters e.g. 1.0,10.0 for lognormal
+# check_schema: [bool]         validates that configuration is valid with the configuration schema
 # work_model                   work model to be used
 #   name [str]                 in LoadOnly, AffineCombination
 #   parameters: [dict]         optional parameters specific to each work model
@@ -22,26 +36,18 @@
 #      PhaseStepper            PhaseStepper algorithm parameters
 # logging_level [str]          set to `info`, `debug`, `warning` or `error`
 # log_to_file [str]            filepath to save the log file (optional)
-# x_procs [int]                number of procs in x direction for rank visualization
-# y_procs [int]                number of procs in y direction for rank visualization
-# z_procs [int]                number of procs in z direction for rank visualization
-# data_stem [str]              base file name of VT load logs
-# phase_ids [list or str]      list of ids of phase to be read in VT load logs e.g. [1, 2, 3] or "1-3"
-# map_file [str]               base file name for VT object/proc mapping
-# file_suffix [str]            file suffix of VT data files (default: "json")
 # output_dir [str]             output directory (default: '.')
-# terminal_background [str]    background color for terminal output
-# generate_meshes [bool]       generate mesh outputs (default: False)
-# generate_multimedia [bool]   generate multimedia visualization (default: False)
-# n_objects [int]              number of objects
-# n_mapped_ranks [int]         number of initially mapped processors
+# LBAF_Viz:
+#   x_ranks: 2                 number of ranks in x direction for rank visualization
+#   y_ranks: 2                 number of ranks in y direction for rank visualization
+#   z_ranks: 1                 number of ranks in z direction for rank visualization
+#   object_jitter: 0.5
+#   rank_qoi: work
+#   object_qoi: load
+#   save_meshes: [bool]        generate mesh outputs (default: False)
+#   force_continuous_object_qoi [bool]
+# file_suffix [str]            file suffix of VT data files (default: "json")
 # communication_degree [int]   object communication degree (no communication if 0)
-# time_sampler                 description of object times sampler:
-#    name [str]                in uniform, lognormal
-#    parameters [list]         parameters e.g. 1.0,10.0 for lognormal
-# volume_sampler               description of object communication volumes sampler:
-#    name [str]                in uniform, lognormal
-#    parameters [list]         parameters e.g. 1.0,10.0 for lognormal
 # write_JSON:                  write load directives for VT as JSON files
 #   compressed: [bool]         compress json files using brotli
 #   suffix: [str]              suffix for generates files. (default: "json")

--- a/config/conf.yaml
+++ b/config/conf.yaml
@@ -3,7 +3,7 @@ from_data:
   data_stem: ../data/synthetic_lb_data/data
   phase_ids:
     - 0
-check_schema: false
+check_schema: False
 
 # Specify work model
 work_model:
@@ -25,7 +25,7 @@ algorithm:
     transfer_strategy: Recursive
     criterion: Tempered
     max_objects_per_transfer: 8
-    deterministic_transfer: true
+    deterministic_transfer: True
 
 # Specify output
 output_dir: ../output
@@ -38,10 +38,10 @@ LBAF_Viz:
   object_jitter: 0.5
   rank_qoi: work
   object_qoi: load
-  save_meshes: true
-  force_continuous_object_qoi: true
+  save_meshes: True
+  force_continuous_object_qoi: True
 write_JSON:
-  compressed: false
+  compressed: False
   suffix: json
-  communications: true
+  communications: True
   offline_LB_compatible: False

--- a/config/conf.yaml
+++ b/config/conf.yaml
@@ -1,6 +1,6 @@
 # Docs
-# param_name_in_conf [type]    Description
-# ---------------------------  ----------------------------------------------------
+# parameter_name [type]        description
+# ---------------------------  -----------------------------------------------------------------------
 # work_model                   work model to be used
 #   name [str]                 in LoadOnly, AffineCombination
 #   parameters: [dict]         optional parameters specific to each work model
@@ -36,10 +36,10 @@
 # n_objects [int]              number of objects
 # n_mapped_ranks [int]         number of initially mapped processors
 # communication_degree [int]   object communication degree (no communication if 0)
-# time_sampler                 description of object times sampler: 
+# time_sampler                 description of object times sampler:
 #    name [str]                in uniform, lognormal
 #    parameters [list]         parameters e.g. 1.0,10.0 for lognormal
-# volume_sampler               description of object communication volumes sampler: 
+# volume_sampler               description of object communication volumes sampler:
 #    name [str]                in uniform, lognormal
 #    parameters [list]         parameters e.g. 1.0,10.0 for lognormal
 # write_JSON:                  write load directives for VT as JSON files

--- a/config/conf.yaml
+++ b/config/conf.yaml
@@ -42,8 +42,8 @@
 #   y_ranks [int]              number of ranks in y direction for rank visualization
 #   z_ranks: [int]             number of ranks in z direction for rank visualization
 #   object_jitter [float]      coefficient of random jitter with magnitude < 1
-#   rank_qoi [str]
-#   object_qoi [str]
+#   rank_qoi [str]             in load, work, None
+#   object_qoi [str]           in load, work, None
 #   save_meshes: [bool]        generate mesh outputs (default: False)
 #   force_continuous_object_qoi [bool] always treat object QOI as continuous or not
 # file_suffix [str]            file suffix of VT data files (default: "json")

--- a/config/conf.yaml
+++ b/config/conf.yaml
@@ -2,9 +2,9 @@
 # parameter_name [type]        description
 # ---------------------------  -----------------------------------------------------------------------
 # from_data:
-#   data_stem: [str]           base file name of VT load logs
-#   phase_ids: [list or str]   list of ids of phase to be read in VT load logs e.g. [1, 2, 3] or "1-3"
-# from_samplers:
+#   data_stem [str]            base file name of VT load logs
+#   phase_ids [list or str]    list of ids of phase to be read in VT load logs e.g. [1, 2, 3] or "1-3"
+# from_samplers [dict]
 #   n_objects [int]            number of objects
 #   n_mapped_ranks [int]       number of initially mapped processors
 #   communication_degree [int] object communication degree (no communication if 0)
@@ -14,14 +14,14 @@
 #   volume_sampler             description of object communication volumes sampler:
 #     name [str]               in uniform, lognormal
 #     parameters [list]        parameters e.g. 1.0,10.0 for lognormal
-# check_schema: [bool]         validates that configuration is valid with the configuration schema
-# work_model                   work model to be used
+# check_schema  [bool]         validates that configuration is valid with the configuration schema
+# work_model [dict]            work model to be used
 #   name [str]                 in LoadOnly, AffineCombination
-#   parameters: [dict]         optional parameters specific to each work model
-# algorithm                    balancing algorithm to be used
+#   parameters [dict]          optional parameters specific to each work model
+# algorithm [dict]             balancing algorithm to be used
 #   name [str]                 in InformAndTransfer, BruteForce, PhaseStepper
-#   parameters: [dict]         parameters specific to each algorithm:
-#     InformAndtransfer:       InformAndtransfer algorithm parameters
+#   parameters [dict]          parameters specific to each algorithm:
+#     InformAndtransfer [dict] InformAndtransfer algorithm parameters
 #       criterion [str]        in Tempered (default), StrictLocalizer
 #       n_iterations [int]     number of load-balancing iterations
 #       deterministic_transfer [bool] for deterministic transfer (default: False)
@@ -31,28 +31,28 @@
 #                              in arbitrary (default), element_id, increasing_times
 #                              decreasing_times, increasing_connectivity,
 #                              fewest_migrations, small_objects
-#      BruteForce:             BruteForce algorithm parameters
+#      BruteForce [dict]       BruteForce algorithm parameters
 #        skip_transfer [bool]  skip transfer phase (default: False)
-#      PhaseStepper            PhaseStepper algorithm parameters
+#      PhaseStepper [dict]     PhaseStepper algorithm parameters
 # logging_level [str]          set to `info`, `debug`, `warning` or `error`
 # log_to_file [str]            filepath to save the log file (optional)
 # output_dir [str]             output directory (default: '.')
-# LBAF_Viz:
+# LBAF_Viz [dict]              Visualization parameters (optional)
 #   x_ranks [int]              number of ranks in x direction for rank visualization
 #   y_ranks [int]              number of ranks in y direction for rank visualization
-#   z_ranks: [int]             number of ranks in z direction for rank visualization
+#   z_ranks [int]              number of ranks in z direction for rank visualization
 #   object_jitter [float]      coefficient of random jitter with magnitude < 1
 #   rank_qoi [str]             in load, work, None
 #   object_qoi [str]           in load, work, None
-#   save_meshes: [bool]        generate mesh outputs (default: False)
+#   save_meshes [bool]         generate mesh outputs (default: False)
 #   force_continuous_object_qoi [bool] always treat object QOI as continuous or not
 # file_suffix [str]            file suffix of VT data files (default: "json")
 # communication_degree [int]   object communication degree (no communication if 0)
-# write_JSON:                  write load directives for VT as JSON files
-#   compressed: [bool]         compress json files using brotli
-#   suffix: [str]              suffix for generates files. (default: "json")
-#   communications: [bool]     use communications (default: False)
-#   offline_LB_compatible: [bool] (default: False)
+# write_JSON                   write load directives for VT as JSON files
+#   compressed [bool]          compress json files using brotli
+#   suffix [str]               suffix for generates files. (default: "json")
+#   communications [bool]      use communications (default: False)
+#   offline_LB_compatible [bool] (default: False)
 
 # Specify input
 from_data:

--- a/config/conf.yaml
+++ b/config/conf.yaml
@@ -20,7 +20,7 @@
 #   parameters: [dict]         optional parameters specific to each work model
 # algorithm                    balancing algorithm to be used
 #   name [str]                 in InformAndTransfer, BruteForce, PhaseStepper
-#   parameters: [dict]         parameters specitic to each algorithm:
+#   parameters: [dict]         parameters specific to each algorithm:
 #     InformAndtransfer:       InformAndtransfer algorithm parameters
 #       criterion [str]        in Tempered (default), StrictLocalizer
 #       n_iterations [int]     number of load-balancing iterations
@@ -38,14 +38,14 @@
 # log_to_file [str]            filepath to save the log file (optional)
 # output_dir [str]             output directory (default: '.')
 # LBAF_Viz:
-#   x_ranks: 2                 number of ranks in x direction for rank visualization
-#   y_ranks: 2                 number of ranks in y direction for rank visualization
-#   z_ranks: 1                 number of ranks in z direction for rank visualization
-#   object_jitter: 0.5
-#   rank_qoi: work
-#   object_qoi: load
+#   x_ranks [int]              number of ranks in x direction for rank visualization
+#   y_ranks [int]              number of ranks in y direction for rank visualization
+#   z_ranks: [int]             number of ranks in z direction for rank visualization
+#   object_jitter [float]      coefficient of random jitter with magnitude < 1
+#   rank_qoi [str]
+#   object_qoi [str]
 #   save_meshes: [bool]        generate mesh outputs (default: False)
-#   force_continuous_object_qoi [bool]
+#   force_continuous_object_qoi [bool] always treat object QOI as continuous or not
 # file_suffix [str]            file suffix of VT data files (default: "json")
 # communication_degree [int]   object communication degree (no communication if 0)
 # write_JSON:                  write load directives for VT as JSON files

--- a/config/conf.yaml
+++ b/config/conf.yaml
@@ -1,3 +1,53 @@
+# Docs
+# param_name_in_conf [type]    Description
+# ---------------------------  ----------------------------------------------------
+# work_model                   work model to be used
+#   name [str]                 in LoadOnly, AffineCombination
+#   parameters: [dict]         optional parameters specific to each work model
+# algorithm                    balancing algorithm to be used
+#   name [str]                 in InformAndTransfer, BruteForce, PhaseStepper
+#   parameters: [dict]         parameters specitic to each algorithm:
+#     InformAndtransfer:       InformAndtransfer algorithm parameters
+#       criterion [str]        in Tempered (default), StrictLocalizer
+#       n_iterations [int]     number of load-balancing iterations
+#       deterministic_transfer [bool] for deterministic transfer (default: False)
+#       n_rounds [int]         number of information rounds
+#       fanout [int]           information fanout index
+#       order_strategy [str]   ordering of objects for transfer
+#                              in arbitrary (default), element_id, increasing_times
+#                              decreasing_times, increasing_connectivity,
+#                              fewest_migrations, small_objects
+#      BruteForce:             BruteForce algorithm parameters
+#        skip_transfer [bool]  skip transfer phase (default: False)
+#      PhaseStepper            PhaseStepper algorithm parameters
+# logging_level [str]          set to `info`, `debug`, `warning` or `error`
+# log_to_file [str]            filepath to save the log file (optional)
+# x_procs [int]                number of procs in x direction for rank visualization
+# y_procs [int]                number of procs in y direction for rank visualization
+# z_procs [int]                number of procs in z direction for rank visualization
+# data_stem [str]              base file name of VT load logs
+# phase_ids [list or str]      list of ids of phase to be read in VT load logs e.g. [1, 2, 3] or "1-3"
+# map_file [str]               base file name for VT object/proc mapping
+# file_suffix [str]            file suffix of VT data files (default: "json")
+# output_dir [str]             output directory (default: '.')
+# terminal_background [str]    background color for terminal output
+# generate_meshes [bool]       generate mesh outputs (default: False)
+# generate_multimedia [bool]   generate multimedia visualization (default: False)
+# n_objects [int]              number of objects
+# n_mapped_ranks [int]         number of initially mapped processors
+# communication_degree [int]   object communication degree (no communication if 0)
+# time_sampler                 description of object times sampler: 
+#    name [str]                in uniform, lognormal
+#    parameters [list]         parameters e.g. 1.0,10.0 for lognormal
+# volume_sampler               description of object communication volumes sampler: 
+#    name [str]                in uniform, lognormal
+#    parameters [list]         parameters e.g. 1.0,10.0 for lognormal
+# write_JSON:                  write load directives for VT as JSON files
+#   compressed: [bool]         compress json files using brotli
+#   suffix: [str]              suffix for generates files. (default: "json")
+#   communications: [bool]     use communications (default: False)
+#   offline_LB_compatible: [bool] (default: False)
+
 # Specify input
 from_data:
   data_stem: ../data/synthetic_lb_data/data

--- a/config/every20phases.yaml
+++ b/config/every20phases.yaml
@@ -45,4 +45,4 @@ LBAF_Viz:
   z_ranks: 1
   object_jitter: 0.5
   rank_qoi: work
-  force_continuous_object_qoi: true
+  force_continuous_object_qoi: True

--- a/config/step.yaml
+++ b/config/step.yaml
@@ -13,7 +13,7 @@ from_data:
     - 8
     - 9
     - 10
-check_schema: false
+check_schema: False
 
 # Specify work model
 work_model:
@@ -28,7 +28,6 @@ algorithm:
   name: PhaseStepper
 
 # Specify output
-terminal_background: light
 output_dir: ../output
 output_file_stem: output_file
 n_ranks: 32
@@ -39,5 +38,5 @@ LBAF_Viz:
   object_jitter: 0.5
   rank_qoi: work
   object_qoi: load
-  save_meshes: true
-  force_continuous_object_qoi: true
+  save_meshes: True
+  force_continuous_object_qoi: True

--- a/config/user-defined-memory-toy-problem.yaml
+++ b/config/user-defined-memory-toy-problem.yaml
@@ -3,7 +3,7 @@ from_data:
   data_stem: ../data/user-defined-memory-toy-problem/toy_mem
   phase_ids:
     - 0
-check_schema: true
+check_schema: True
 
 # Specify work model
 work_model:
@@ -27,7 +27,7 @@ algorithm:
     transfer_strategy: Clustering
     criterion: Tempered
     max_objects_per_transfer: 32
-    deterministic_transfer: true
+    deterministic_transfer: True
 
 # Specify output
 output_dir: ../output
@@ -40,10 +40,10 @@ LBAF_Viz:
   object_jitter: 0.5
   rank_qoi: load
   object_qoi: load
-  save_meshes: true
-  force_continuous_object_qoi: true
+  save_meshes: True
+  force_continuous_object_qoi: True
 write_JSON:
-  compressed: true
+  compressed: True
   suffix: json
-  communications: true
-  offline_LB_compatible: true
+  communications: True
+  offline_LB_compatible: True

--- a/docs/pages/configuration.rst
+++ b/docs/pages/configuration.rst
@@ -44,7 +44,6 @@ Parameters
 * **output_dir [str]**: output directory (default: '.')
 * **overwrite_validator [bool]**: download and overwrite JSON_data_files_validator from VT (default: True)
 * **check_schema [bool]**: checking schema in VT input files (optional, default: True)
-* **terminal_background [str]**: background color for terminal output
 * **generate_meshes [bool]**: generate mesh outputs (default: False)
 * **generate_multimedia [bool]**: generate multimedia visualization (default: False)
 * **n_objects [int]**: number of objects
@@ -97,7 +96,6 @@ Example configuration
     #logging_level: debug
     #overwrite_validator: False
     check_schema: False
-    terminal_background: light
     generate_multimedia: False
     output_dir: ../../../output
     output_file_stem: output_file

--- a/docs/pages/testing.rst
+++ b/docs/pages/testing.rst
@@ -91,7 +91,6 @@ Acceptance Test Configuration
   #check_schema: False
   n_ranks: 4
   logging_level: info
-  terminal_background: light
   output_dir: /__w/LB-analysis-framework/LB-analysis-framework/output
   output_file_stem: output_file
   generate_meshes:
@@ -138,7 +137,6 @@ Stepper Test Configuration
   #overwrite_validator: False
   #check_schema: False
   log_to_file: /__w/LB-analysis-framework/LB-analysis-framework/log.txt
-  terminal_background: light
   generate_multimedia: False
   output_dir: /__w/LB-analysis-framework/LB-analysis-framework/output
   output_file_stem: output_file

--- a/scripts/add-license-perl.pl
+++ b/scripts/add-license-perl.pl
@@ -23,7 +23,7 @@ sub make_header {
     open TEMP, "<$template" or die "Can't access template\n";
     for (<TEMP>) {
         if (/file-name/) {
-            print $out "#" . (" " x $lenright) . $name . "\n";
+            print $out '#' . (" " x $lenright) . $name . 'n';
         } else {
             print $out "$_";
         }

--- a/scripts/test_lbaf.py
+++ b/scripts/test_lbaf.py
@@ -8,7 +8,7 @@ def run_tests():
         print(f"File: {imbalance_file} does not exist!")
         sys.exit(1)
 
-    with open(imbalance_file, "r", encoding="utf-8") as imb_file:
+    with open(imbalance_file, 'r', encoding="utf-8") as imb_file:
         imb_level = float(imb_file.read())
         print(f"@@@@@ FOUND IMBALANCE: {imb_level} @@@@@")
         if imb_level < 0.000001:

--- a/scripts/test_stepper.py
+++ b/scripts/test_stepper.py
@@ -8,7 +8,7 @@ def stepper_test():
         print(f"File: {log_file} does not exist!")
         sys.exit(1)
 
-    with open(log_file, "r", encoding="utf-8") as logger_output:
+    with open(log_file, 'r', encoding="utf-8") as logger_output:
         output_str = logger_output.read()
         regex_list = [
             "cardinality: 32 sum: 10.5817 imbalance: 0.992173",

--- a/src/lbaf/Applications/LBAF_app.py
+++ b/src/lbaf/Applications/LBAF_app.py
@@ -99,12 +99,6 @@ class InternalParameters:
 
             # Retrieve optional parameters
             self.save_meshes = viz.get("save_meshes", False)
-
-            if self.save_meshes and sys.version_info.major == 3 and sys.version_info.minor == 9:
-                self.__logger.error("save_meshes=True. Not supported with Python 3.9")
-                sys.excepthook = exc_handler
-                raise SystemExit(1)
-
             self.continuous_object_qoi = viz.get("force_continuous_object_qoi", False)
         else:
             # No visualization quantities of interest

--- a/src/lbaf/Applications/LBAF_app.py
+++ b/src/lbaf/Applications/LBAF_app.py
@@ -61,6 +61,7 @@ class InternalParameters:
 
     def validate_configuration(self, config: dict):
         """Configuration file validation."""
+
         ConfigurationValidator(
             config_to_validate=config, logger=self.__logger).main()
 
@@ -98,6 +99,12 @@ class InternalParameters:
 
             # Retrieve optional parameters
             self.save_meshes = viz.get("save_meshes", False)
+
+            if self.save_meshes and sys.version_info.major == 3 and sys.version_info.minor == 9:
+                self.__logger.error("save_meshes=True. Not supported with Python 3.9")
+                sys.excepthook = exc_handler
+                raise SystemExit(1)
+
             self.continuous_object_qoi = viz.get("force_continuous_object_qoi", False)
         else:
             # No visualization quantities of interest

--- a/src/lbaf/Applications/LBAF_app.py
+++ b/src/lbaf/Applications/LBAF_app.py
@@ -165,14 +165,11 @@ class Application:
     __logger: Logger
     __parameters: InternalParameters
     __json_writer: Union[VTDataWriter,None]
-
-    """LBAF application class."""
-    def __init__(self):
-        # Init logger to instance variable. Initially the root logger.
-        self.__logger = get_logger()
+    __args: dict
 
     def __configure(self, path: str):
         """Configure the application using the configuration file at the given path"""
+
         if os.path.splitext(path)[-1] in [".yml", ".yaml"]:
             # Try to open configuration file in read+text mode
             try:
@@ -200,7 +197,6 @@ class Application:
         self.__logger = get_logger(
             name="lbaf",
             level=lvl,
-            theme=data.get("terminal_background", None),
             log_to_console=data.get("log_to_console", None) is None,
             log_to_file=None if log_to_file is None else abspath(data.get("log_to_file"), relative_to=config_dir)
         )
@@ -220,13 +216,8 @@ class Application:
 
         return data
 
-    def __get_config_path(self)-> str:
-        """Find the config file from the '-configuration' command line argument and returns its absolute path
-        (if configuration file path is relative it is searched in the current working directory and at the end in the
-        {PROJECT_PATH}/config directory)
-
-        :raises FileNotFoundError: if configuration file cannot be found
-        """
+    def __parse_args(self) -> dict:
+        """Parse arguments"""
 
         parser = argparse.ArgumentParser(allow_abbrev=False)
         parser.add_argument("-c", "--configuration",
@@ -235,25 +226,31 @@ class Application:
             default=None
         )
         args = parser.parse_args()
+
+        self.__args = args
+
+    def __get_config_path(self)-> str:
+        """Find the config file from the '-configuration' command line argument and returns its absolute path
+        (if configuration file path is relative it is searched in the current working directory and at the end in the
+        {PROJECT_PATH}/config directory)
+
+        :raises FileNotFoundError: if configuration file cannot be found
+        """
+
         path = None
         path_list = []
 
-        if args.configuration is None:
-            self.__logger.warning("No configuration file given. Fallback to default `conf.yaml` file in "
-            "working directory or in the project config directory !")
-            args.configuration = "conf.yaml"
-
         # search config file in the current working directory if relative
-        path = abspath(args.configuration)
+        path = abspath(self.__args.configuration)
         path_list.append(path)
         if (
             path is not None and
             not os.path.isfile(path) and
-            not os.path.isabs(args.configuration) and PROJECT_PATH is not None
+            not os.path.isabs(self.__args.configuration) and PROJECT_PATH is not None
         ):
             # then search config file relative to the config folder
             search_dir = abspath("config", relative_to=PROJECT_PATH)
-            path = search_dir + '/' + args.configuration
+            path = search_dir + '/' + self.__args.configuration
             path_list.append(path)
 
         if not os.path.isfile(path):
@@ -273,6 +270,18 @@ class Application:
 
     def run(self):
         """Runs the LBAF application"""
+        # Parse command line arguments
+        self.__parse_args()
+
+        # Init logger and set as an instance variable.
+        self.__logger = get_logger()
+
+        # Warn if default configuration is used because not set as argument
+        if self.__args.configuration is None:
+            self.__logger.warning("No configuration file given. Fallback to default `conf.yaml` file in "
+            "working directory or in the project config directory !")
+            self.__args.configuration = "conf.yaml"
+
         # Find configuration file absolute path
         config_file = self.__get_config_path()
 

--- a/src/lbaf/Applications/LBAF_app.py
+++ b/src/lbaf/Applications/LBAF_app.py
@@ -482,7 +482,7 @@ class Application:
                 "imbalance.txt" if self.__parameters.output_dir is None
                 else os.path.join(
                     self.__parameters.output_dir,
-                    "imbalance.txt"), "w", encoding="utf-8") as imbalance_file:
+                    "imbalance.txt"), 'w', encoding="utf-8") as imbalance_file:
                 imbalance_file.write(f"{l_stats.get_imbalance()}")
 
         # If this point is reached everything went fine

--- a/src/lbaf/Applications/MoveCountsViewer.py
+++ b/src/lbaf/Applications/MoveCountsViewer.py
@@ -172,7 +172,7 @@ class MoveCountsViewer:
         # directed_sizes = {} (unused)
         for i in range(self.n_processors):
             # Iterate over all files
-            with open(f"{self.input_file_name}.{i}.{self.input_file_suffix}", "r", encoding="utf-8") as input_file:
+            with open(f"{self.input_file_name}.{i}.{self.input_file_suffix}", 'r', encoding="utf-8") as input_file:
                 # Instantiate CSV reader
                 reader = csv.reader(input_file, delimiter=",")
 

--- a/src/lbaf/Applications/rank_object_enumerator.py
+++ b/src/lbaf/Applications/rank_object_enumerator.py
@@ -306,7 +306,7 @@ def main():
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
     out_name = os.path.join(output_dir, "optimal-arrangements.csv")
-    with open(out_name, "w", encoding="utf-8") as input_file:
+    with open(out_name, 'w', encoding="utf-8") as input_file:
         writer = csv.writer(input_file)
         for a in a_min_max:
             writer.writerow(a)

--- a/src/lbaf/IO/lbsConfigurationUpgrader.py
+++ b/src/lbaf/IO/lbsConfigurationUpgrader.py
@@ -23,6 +23,15 @@ from .. import PROJECT_PATH
 #     return dumper.represent_scalar(u'tag:yaml.org,2002:float', text)
 # yaml.add_representer(float, float_representer)
 
+def bool_representer(dumper, value):
+    """Overrides default yaml representation of boolean values for the ConfigurationDumper"""
+
+    if value:
+        text = 'True'
+    else:
+        text = 'False'
+    return dumper.represent_scalar('tag:yaml.org,2002:bool', text)
+
 class UpgradeAction(Enum):
     """Upgrade action"""
 
@@ -44,6 +53,7 @@ class ConfigurationUpgrader:
 
     def __init__(self, logger: Logger):
         self.__dumper = ConfigurationDumper
+        self.__dumper.add_representer(bool, bool_representer)
         self.__logger = logger
         self.__sections = cast(dict, ConfigurationValidator.allowed_keys(group=True))
 
@@ -67,7 +77,7 @@ class ConfigurationUpgrader:
             if yaml_node.endswith("\n" + indent_str):
                 yaml_node = yaml_node[:-(indent_size + 1)]
         else:
-            yaml_node = " " + yaml.representer.SafeRepresenter().represent_data(value).value
+            yaml_node = " " + yaml.representer.BaseRepresenter().represent_data(value).value
         yaml_file.write(yaml_node)
         yaml_file.write("\n")
 
@@ -97,7 +107,23 @@ class ConfigurationUpgrader:
             raise ValueError("The `key` must be a valid string")
 
         conf = None
+        file_comment = None
         with open(file_path, "r", encoding="utf-8") as yaml_file:
+            lines = yaml_file.readlines()
+            for line in lines:
+                # if comment is a section comment
+                section_comments = [f"# Specify {k}" for k in self.__sections]
+                if line.strip() in section_comments:
+                    break
+                # else if another comment or empty line consider it is aprt of the file comment (at the top of the file)
+                if line.startswith('#') or line.strip() == '':
+                    if file_comment is None:
+                        file_comment = ''
+                    file_comment = file_comment + line
+                else:
+                    break # reach 1st not commented line and non-empty line = end of file comment
+            yaml_file.seek(0)
+
             yaml_content = yaml_file.read()
             conf = yaml.safe_load(yaml_content)
             node = conf
@@ -129,6 +155,9 @@ class ConfigurationUpgrader:
                 node=node[key]
 
         with open(file_path, "w", encoding="utf-8") as yaml_file:
+            if file_comment is not None:
+                yaml_file.write(file_comment)
+
             added_keys = []
             for section in self.__sections:
                 if yaml_file.tell() > 0:
@@ -156,7 +185,7 @@ class ConfigurationUpgrader:
                 yaml_file.write("# Other\n")
                 for k in intersect:
                     value = conf.get(k)
-                    self.write_node(k, value, yaml_file)
+                    self.write_node(k, _alue, yaml_file)
                     added_keys.append(k)
 
         self.__logger.debug("File has been successfully upgraded")

--- a/src/lbaf/IO/lbsConfigurationUpgrader.py
+++ b/src/lbaf/IO/lbsConfigurationUpgrader.py
@@ -185,7 +185,7 @@ class ConfigurationUpgrader:
                 yaml_file.write("# Other\n")
                 for k in intersect:
                     value = conf.get(k)
-                    self.write_node(k, _alue, yaml_file)
+                    self.write_node(k, value, yaml_file)
                     added_keys.append(k)
 
         self.__logger.debug("File has been successfully upgraded")

--- a/src/lbaf/IO/lbsConfigurationUpgrader.py
+++ b/src/lbaf/IO/lbsConfigurationUpgrader.py
@@ -27,9 +27,9 @@ def bool_representer(dumper, value):
     """Overrides default yaml representation of boolean values for the ConfigurationDumper"""
 
     if value:
-        text = 'True'
+        text = "True"
     else:
-        text = 'False'
+        text = "False"
     return dumper.represent_scalar('tag:yaml.org,2002:bool', text)
 
 class UpgradeAction(Enum):
@@ -62,24 +62,24 @@ class ConfigurationUpgrader:
         indent_str = " " * indent_size
         yaml_file.write(f"{k}:")
         if isinstance(value, list) or isinstance(value, dict):
-            yaml_file.write("\n")
+            yaml_file.write('\n')
             yaml_file.write(indent_str)
             yaml_node = yaml.dump(
                 value,
                 indent=indent_size,
-                line_break="\n",
+                line_break='\n',
                 sort_keys=False,
                 Dumper=self.__dumper
             ).replace(
-                "\n",
-                "\n" + indent_str
+                '\n',
+                '\n' + indent_str
             )
-            if yaml_node.endswith("\n" + indent_str):
+            if yaml_node.endswith('\n' + indent_str):
                 yaml_node = yaml_node[:-(indent_size + 1)]
         else:
             yaml_node = " " + yaml.representer.BaseRepresenter().represent_data(value).value
         yaml_file.write(yaml_node)
-        yaml_file.write("\n")
+        yaml_file.write('\n')
 
     def upgrade(
         self,
@@ -108,7 +108,7 @@ class ConfigurationUpgrader:
 
         conf = None
         file_comment = None
-        with open(file_path, "r", encoding="utf-8") as yaml_file:
+        with open(file_path, 'r', encoding="utf-8") as yaml_file:
             lines = yaml_file.readlines()
             for line in lines:
                 # if comment is a section comment
@@ -158,14 +158,14 @@ class ConfigurationUpgrader:
 
                 node=node[key]
 
-        with open(file_path, "w", encoding="utf-8") as yaml_file:
+        with open(file_path, 'w', encoding="utf-8") as yaml_file:
             if file_comment is not None:
-                yaml_file.write(file_comment + "\n")
+                yaml_file.write(file_comment + '\n')
 
             added_keys = []
             for section in self.__sections:
                 if yaml_file.tell() > 0:
-                    yaml_file.write("\n")
+                    yaml_file.write('\n')
                 yaml_file.write(f"# Specify {section}\n")
                 for k in self.__sections[section]:
                     if k in conf.keys():
@@ -185,7 +185,7 @@ class ConfigurationUpgrader:
                     PROJECT_PATH
                 )
                 if yaml_file.tell() > 0:
-                    yaml_file.write("\n")
+                    yaml_file.write('\n')
                 yaml_file.write("# Other\n")
                 for k in intersect:
                     value = conf.get(k)

--- a/src/lbaf/IO/lbsConfigurationUpgrader.py
+++ b/src/lbaf/IO/lbsConfigurationUpgrader.py
@@ -122,6 +122,10 @@ class ConfigurationUpgrader:
                     file_comment = file_comment + line
                 else:
                     break # reach 1st not commented line and non-empty line = end of file comment
+
+            if file_comment is not None:
+                file_comment = file_comment.strip() # removes potential eol at the end
+
             yaml_file.seek(0)
 
             yaml_content = yaml_file.read()
@@ -156,7 +160,7 @@ class ConfigurationUpgrader:
 
         with open(file_path, "w", encoding="utf-8") as yaml_file:
             if file_comment is not None:
-                yaml_file.write(file_comment)
+                yaml_file.write(file_comment + "\n")
 
             added_keys = []
             for section in self.__sections:

--- a/src/lbaf/IO/lbsConfigurationValidator.py
+++ b/src/lbaf/IO/lbsConfigurationValidator.py
@@ -190,13 +190,13 @@ class ConfigurationValidator:
     def allowed_keys(group: bool =  False) -> Union[List[str], Dict[str, List[str]]]:
         """Returns allowed keys at configuration root level grouped by some group key or as a flat list"""
         sections = {
-            "input": ["from_data"],
+            "input": ["from_data", "from_samplers", "check_schema"],
             "work model": ["work_model"],
             "algorithm": ["brute_force_optimization", "algorithm"],
             "output": [
-                "logging_level", "log_to_file", "overwrite_validator", "check_schema", "terminal_background",
+                "logging_level", "log_to_file", "overwrite_validator",
                 "generate_multimedia", "output_dir", "output_file_stem", "n_ranks",
-                "LBAF_Viz"
+                "LBAF_Viz", "write_JSON"
             ]
         }
 

--- a/src/lbaf/IO/lbsConfigurationValidator.py
+++ b/src/lbaf/IO/lbsConfigurationValidator.py
@@ -29,7 +29,6 @@ ALLOWED_ALGORITHMS = (
 ALLOWED_CRITERIA = ("Tempered", "StrictLocalizing")
 ALLOWED_LOGGING_LEVELS = ("info", "debug", "warning", "error")
 ALLOWED_LOAD_VOLUME_SAMPLER = ("uniform", "lognormal")
-ALLOWED_TERMINAL_BACKGROUND = ("light", "dark")
 
 
 def get_error_message(iterable_collection: tuple) -> str:
@@ -80,11 +79,6 @@ class ConfigurationValidator:
                 str, Use(str.lower),
                 lambda f: f in ALLOWED_LOGGING_LEVELS,
                 error=f"{get_error_message(ALLOWED_LOGGING_LEVELS)} must be chosen"),
-            Optional("terminal_background"): And(
-                str,
-                Use(str.lower),
-                lambda g: g in ALLOWED_TERMINAL_BACKGROUND,
-                error=f"{get_error_message(ALLOWED_TERMINAL_BACKGROUND)} must be chosen"),
             Optional("output_dir"): str,
             Optional("LBAF_Viz"): {
                 "x_ranks": And(

--- a/src/lbaf/IO/lbsVTDataWriter.py
+++ b/src/lbaf/IO/lbsVTDataWriter.py
@@ -93,7 +93,7 @@ class VTDataWriter:
         if self.__compress:
             serial_json = brotli.compress(
                 string=serial_json.encode("utf-8"), mode=brotli.MODE_TEXT)
-        with open(file_name, "wb" if self.__compress else "w") as json_file:
+        with open(file_name, "wb" if self.__compress else 'w') as json_file:
             json_file.write(serial_json)
 
         # Return JSON file name

--- a/src/lbaf/IO/lbsVisualizer.py
+++ b/src/lbaf/IO/lbsVisualizer.py
@@ -735,7 +735,7 @@ class Visualizer:
             if sys.version_info.major == 3 and sys.version_info.minor == 9:
                 self.__logger.error(
                     "Cannot save meshes when using Python 3.9 (issue with vtk 9.1.0). "
-                    "Please use Python 3.8 (vtk 9.0.1) to save meshes."
+                    "Please use Python 3.8 (vtk 9.0.1)."
                 )
                 raise SystemExit(1)
 

--- a/src/lbaf/IO/lbsVisualizer.py
+++ b/src/lbaf/IO/lbsVisualizer.py
@@ -1,5 +1,6 @@
 from logging import Logger
 import os
+import sys
 import math
 import numbers
 import random
@@ -8,7 +9,7 @@ import matplotlib.pyplot as plt
 
 from .lbsGridStreamer import GridStreamer
 from ..Model.lbsPhase import Phase
-
+from ..Utils.exception_handler import exc_handler
 
 class Visualizer:
     """A class to visualize LBAF results via mesh files and VTK views."""
@@ -731,6 +732,13 @@ class Visualizer:
 
         # Write ExodusII rank mesh when requested
         if save_meshes:
+            if sys.version_info.major == 3 and sys.version_info.minor == 9:
+                self.__logger.error(
+                    "Cannot save meshes when using Python 3.9 (issue with vtk 9.1.0). "
+                    "Please use Python 3.8 (vtk 9.0.1) to save meshes."
+                )
+                raise SystemExit(1)
+
             # Create grid streamer
             streamer = GridStreamer(
                 self.__rank_points,

--- a/src/lbaf/Utils/logging.py
+++ b/src/lbaf/Utils/logging.py
@@ -104,8 +104,6 @@ def get_logger(
     if name in loggers:
         return loggers[name]
 
-    print("Init logger " + name + "...")
-
     # init new logger
     logger = logging.getLogger(name)
     if level is not None:

--- a/src/lbaf/Utils/logging.py
+++ b/src/lbaf/Utils/logging.py
@@ -26,7 +26,7 @@ Logger = logging.Logger
 
 class CustomFormatter(Formatter):
     """Formatter able to write colored logs
-    Colors are used to colorize log meta information such as
+    Colors are used to colorize log meta information such as:
     - the calling module name
     - the caling function name (available with 'extended' format only)
     - logging level (available with 'extended' format only)

--- a/tests/config/conf_correct_001.yml
+++ b/tests/config/conf_correct_001.yml
@@ -24,7 +24,7 @@ algorithm:
     transfer_strategy: Recursive
     criterion: Tempered
     max_objects_per_transfer: 8
-    deterministic_transfer: true
+    deterministic_transfer: True
 
 # Specify output
 output_dir: ../../output
@@ -37,4 +37,4 @@ LBAF_Viz:
   object_jitter: 0.5
   rank_qoi: None
   object_qoi: None
-  force_continuous_object_qoi: true
+  force_continuous_object_qoi: True

--- a/tests/config/conf_correct_002.yml
+++ b/tests/config/conf_correct_002.yml
@@ -1,4 +1,18 @@
 # Specify input
+from_samplers:
+  n_objects: 200
+  n_mapped_ranks: 2
+  communication_degree: 20
+  load_sampler:
+    name: lognormal
+    parameters:
+      - 1.0
+      - 10.0
+  volume_sampler:
+    name: lognormal
+    parameters:
+      - 1.0
+      - 10.0
 
 # Specify work model
 work_model:
@@ -20,7 +34,7 @@ algorithm:
     transfer_strategy: Recursive
     criterion: Tempered
     max_objects_per_transfer: 8
-    deterministic_transfer: true
+    deterministic_transfer: True
 
 # Specify output
 output_dir: ../../../output
@@ -33,20 +47,4 @@ LBAF_Viz:
   object_jitter: 0.5
   rank_qoi: None
   object_qoi: None
-  force_continuous_object_qoi: true
-
-# Other
-from_samplers:
-  n_objects: 200
-  n_mapped_ranks: 2
-  communication_degree: 20
-  load_sampler:
-    name: lognormal
-    parameters:
-      - 1.0
-      - 10.0
-  volume_sampler:
-    name: lognormal
-    parameters:
-      - 1.0
-      - 10.0
+  force_continuous_object_qoi: True

--- a/tests/config/conf_correct_003.yml
+++ b/tests/config/conf_correct_003.yml
@@ -13,7 +13,7 @@ work_model:
     gamma: 0.0
 
 # Specify algorithm
-brute_force_optimization: true
+brute_force_optimization: True
 algorithm:
   name: InformAndTransfer
   phase_id: 0
@@ -25,7 +25,7 @@ algorithm:
     transfer_strategy: Recursive
     criterion: Tempered
     max_objects_per_transfer: 8
-    deterministic_transfer: true
+    deterministic_transfer: True
 
 # Specify output
 logging_level: debug
@@ -39,4 +39,4 @@ LBAF_Viz:
   object_jitter: 0.5
   rank_qoi: None
   object_qoi: None
-  force_continuous_object_qoi: true
+  force_continuous_object_qoi: True

--- a/tests/config/conf_correct_brute_force.yml
+++ b/tests/config/conf_correct_brute_force.yml
@@ -13,7 +13,7 @@ work_model:
     gamma: 0.0
 
 # Specify algorithm
-brute_force_optimization: true
+brute_force_optimization: True
 algorithm:
   name: BruteForce
   phase_id: 0
@@ -30,4 +30,4 @@ LBAF_Viz:
   object_jitter: 0.5
   rank_qoi: None
   object_qoi: None
-  force_continuous_object_qoi: true
+  force_continuous_object_qoi: True

--- a/tests/config/conf_correct_from_data_min_config.yml
+++ b/tests/config/conf_correct_from_data_min_config.yml
@@ -27,4 +27,4 @@ LBAF_Viz:
   object_jitter: 0.5
   rank_qoi: work
   object_qoi: work
-  force_continuous_object_qoi: true
+  force_continuous_object_qoi: True

--- a/tests/config/conf_correct_from_samplers_no_ll.yml
+++ b/tests/config/conf_correct_from_samplers_no_ll.yml
@@ -1,4 +1,18 @@
 # Specify input
+from_samplers:
+  n_objects: 200
+  n_mapped_ranks: 2
+  communication_degree: 20
+  load_sampler:
+    name: lognormal
+    parameters:
+      - 1.0
+      - 10.0
+  volume_sampler:
+    name: lognormal
+    parameters:
+      - 1.0
+      - 10.0
 
 # Specify work model
 work_model:
@@ -20,7 +34,7 @@ algorithm:
     transfer_strategy: Recursive
     criterion: Tempered
     max_objects_per_transfer: 8
-    deterministic_transfer: true
+    deterministic_transfer: True
 
 # Specify output
 output_dir: ../../../output
@@ -33,20 +47,4 @@ LBAF_Viz:
   object_jitter: 0.5
   rank_qoi: None
   object_qoi: None
-  force_continuous_object_qoi: true
-
-# Other
-from_samplers:
-  n_objects: 200
-  n_mapped_ranks: 2
-  communication_degree: 20
-  load_sampler:
-    name: lognormal
-    parameters:
-      - 1.0
-      - 10.0
-  volume_sampler:
-    name: lognormal
-    parameters:
-      - 1.0
-      - 10.0
+  force_continuous_object_qoi: True

--- a/tests/config/conf_correct_phase_ids_str_001.yml
+++ b/tests/config/conf_correct_phase_ids_str_001.yml
@@ -23,7 +23,7 @@ algorithm:
     transfer_strategy: Recursive
     criterion: Tempered
     max_objects_per_transfer: 8
-    deterministic_transfer: true
+    deterministic_transfer: True
 
 # Specify output
 output_dir: ../../../output
@@ -36,4 +36,4 @@ LBAF_Viz:
   object_jitter: 0.5
   rank_qoi: None
   object_qoi: None
-  force_continuous_object_qoi: true
+  force_continuous_object_qoi: True

--- a/tests/config/conf_vt_writer_stepper_test.yml
+++ b/tests/config/conf_vt_writer_stepper_test.yml
@@ -13,7 +13,7 @@ from_data:
     - 8
     - 9
     - 10
-check_schema: false
+check_schema: False
 
 # Specify work model
 work_model:
@@ -28,13 +28,11 @@ algorithm:
   name: PhaseStepper
 
 # Specify output
-terminal_background: light
 output_dir: ../output/vt_writer_stepper_test
 output_file_stem: output_file
 n_ranks: 32
-
 write_JSON:
-  compressed: true
+  compressed: True
   suffix: json
-  communications: true
-  offline_LB_compatible: true
+  communications: True
+  offline_LB_compatible: True

--- a/tests/config/conf_wrong_algorithm_invalid_001.yml
+++ b/tests/config/conf_wrong_algorithm_invalid_001.yml
@@ -29,4 +29,4 @@ LBAF_Viz:
   object_jitter: 0.5
   rank_qoi: work
   object_qoi: work
-  force_continuous_object_qoi: true
+  force_continuous_object_qoi: True

--- a/tests/config/conf_wrong_algorithm_invalid_002.yml
+++ b/tests/config/conf_wrong_algorithm_invalid_002.yml
@@ -22,10 +22,9 @@ algorithm:
     transfer_strategy: Recursive
     criterion: Tempered
     max_objects_per_transfer: 8
-    deterministic_transfer: true
+    deterministic_transfer: True
 
 # Specify output
-terminal_background: light
 output_dir: ../../../output
 output_file_stem: output_file
 n_ranks: 4
@@ -36,4 +35,4 @@ LBAF_Viz:
   object_jitter: 0.5
   rank_qoi: None
   object_qoi: None
-  force_continuous_object_qoi: true
+  force_continuous_object_qoi: True

--- a/tests/config/conf_wrong_data_and_sampling.yml
+++ b/tests/config/conf_wrong_data_and_sampling.yml
@@ -3,6 +3,20 @@ from_data:
   data_stem: ../data/synthetic_lb_data/data
   phase_ids:
     - 0
+from_samplers:
+  n_objects: 200
+  n_mapped_ranks: 2
+  communication_degree: 20
+  load_sampler:
+    name: lognormal
+    parameters:
+      - 1.0
+      - 10.0
+  volume_sampler:
+    name: lognormal
+    parameters:
+      - 1.0
+      - 10.0
 
 # Specify work model
 work_model:
@@ -23,10 +37,9 @@ algorithm:
     transfer_strategy: Recursive
     criterion: Tempered
     max_objects_per_transfer: 8
-    deterministic_transfer: true
+    deterministic_transfer: True
 
 # Specify output
-terminal_background: light
 output_dir: ../../../output
 output_file_stem: output_file
 n_ranks: 4
@@ -37,20 +50,4 @@ LBAF_Viz:
   object_jitter: 0.5
   rank_qoi: None
   object_qoi: None
-  force_continuous_object_qoi: true
-
-# Other
-from_samplers:
-  n_objects: 200
-  n_mapped_ranks: 2
-  communication_degree: 20
-  load_sampler:
-    name: lognormal
-    parameters:
-      - 1.0
-      - 10.0
-  volume_sampler:
-    name: lognormal
-    parameters:
-      - 1.0
-      - 10.0
+  force_continuous_object_qoi: True

--- a/tests/config/conf_wrong_from_data_phase_name.yml
+++ b/tests/config/conf_wrong_from_data_phase_name.yml
@@ -21,10 +21,9 @@ algorithm:
     transfer_strategy: Recursive
     criterion: Tempered
     max_objects_per_transfer: 8
-    deterministic_transfer: true
+    deterministic_transfer: True
 
 # Specify output
-terminal_background: light
 output_dir: ../../../output
 output_file_stem: output_file
 n_ranks: 4
@@ -35,4 +34,4 @@ LBAF_Viz:
   object_jitter: 0.5
   rank_qoi: None
   object_qoi: None
-  force_continuous_object_qoi: true
+  force_continuous_object_qoi: True

--- a/tests/config/conf_wrong_from_data_phase_type.yml
+++ b/tests/config/conf_wrong_from_data_phase_type.yml
@@ -23,10 +23,9 @@ algorithm:
     transfer_strategy: Recursive
     criterion: Tempered
     max_objects_per_transfer: 8
-    deterministic_transfer: true
+    deterministic_transfer: True
 
 # Specify output
-terminal_background: light
 output_dir: ../../../output
 output_file_stem: output_file
 n_ranks: 4
@@ -37,4 +36,4 @@ LBAF_Viz:
   object_jitter: 0.5
   rank_qoi: None
   object_qoi: None
-  force_continuous_object_qoi: true
+  force_continuous_object_qoi: True

--- a/tests/config/conf_wrong_from_samplers_load_sampler_001.yml
+++ b/tests/config/conf_wrong_from_samplers_load_sampler_001.yml
@@ -1,4 +1,19 @@
 # Specify input
+from_samplers:
+  n_objects: 200
+  n_mapped_ranks: 2
+  communication_degree: 20
+  load_sampler:
+    name: lognormal
+    parameters:
+      - 1.0
+      - 10.0
+      - 5.0
+  volume_sampler:
+    name: lognormal
+    parameters:
+      - 1.0
+      - 10.0
 
 # Specify work model
 work_model:
@@ -19,10 +34,9 @@ algorithm:
     transfer_strategy: Recursive
     criterion: Tempered
     max_objects_per_transfer: 8
-    deterministic_transfer: true
+    deterministic_transfer: True
 
 # Specify output
-terminal_background: light
 output_dir: ../../../output
 output_file_stem: output_file
 n_ranks: 4
@@ -33,21 +47,4 @@ LBAF_Viz:
   object_jitter: 0.5
   rank_qoi: None
   object_qoi: None
-  force_continuous_object_qoi: true
-
-# Other
-from_samplers:
-  n_objects: 200
-  n_mapped_ranks: 2
-  communication_degree: 20
-  load_sampler:
-    name: lognormal
-    parameters:
-      - 1.0
-      - 10.0
-      - 5.0
-  volume_sampler:
-    name: lognormal
-    parameters:
-      - 1.0
-      - 10.0
+  force_continuous_object_qoi: True

--- a/tests/config/conf_wrong_from_samplers_load_sampler_002.yml
+++ b/tests/config/conf_wrong_from_samplers_load_sampler_002.yml
@@ -1,4 +1,17 @@
 # Specify input
+from_samplers:
+  n_objects: 200
+  n_mapped_ranks: 2
+  communication_degree: 20
+  load_sampler:
+    name: lognormal
+    parameters:
+      - 1.0
+      - 10.0
+  volume_sampler:
+    name: lognormal
+    parameters:
+      - 1.0
 
 # Specify work model
 work_model:
@@ -19,10 +32,9 @@ algorithm:
     transfer_strategy: Recursive
     criterion: Tempered
     max_objects_per_transfer: 8
-    deterministic_transfer: true
+    deterministic_transfer: True
 
 # Specify output
-terminal_background: light
 output_dir: ../../../output
 output_file_stem: output_file
 n_ranks: 4
@@ -33,19 +45,4 @@ LBAF_Viz:
   object_jitter: 0.5
   rank_qoi: None
   object_qoi: None
-  force_continuous_object_qoi: true
-
-# Other
-from_samplers:
-  n_objects: 200
-  n_mapped_ranks: 2
-  communication_degree: 20
-  load_sampler:
-    name: lognormal
-    parameters:
-      - 1.0
-      - 10.0
-  volume_sampler:
-    name: lognormal
-    parameters:
-      - 1.0
+  force_continuous_object_qoi: True

--- a/tests/config/conf_wrong_from_samplers_load_sampler_003.yml
+++ b/tests/config/conf_wrong_from_samplers_load_sampler_003.yml
@@ -1,4 +1,18 @@
 # Specify input
+from_samplers:
+  n_objects: 200
+  n_mapped_ranks: 2
+  communication_degree: 20
+  load_sampler:
+    name: lognormal
+    parameters:
+      - 1.0
+      - '10.0'
+  volume_sampler:
+    name: lognormal
+    parameters:
+      - 1.0
+      - 10.0
 
 # Specify work model
 work_model:
@@ -19,10 +33,9 @@ algorithm:
     transfer_strategy: Recursive
     criterion: Tempered
     max_objects_per_transfer: 8
-    deterministic_transfer: true
+    deterministic_transfer: True
 
 # Specify output
-terminal_background: light
 output_dir: ../../../output
 output_file_stem: output_file
 n_ranks: 4
@@ -33,20 +46,4 @@ LBAF_Viz:
   object_jitter: 0.5
   rank_qoi: None
   object_qoi: None
-  force_continuous_object_qoi: true
-
-# Other
-from_samplers:
-  n_objects: 200
-  n_mapped_ranks: 2
-  communication_degree: 20
-  load_sampler:
-    name: lognormal
-    parameters:
-      - 1.0
-      - '10.0'
-  volume_sampler:
-    name: lognormal
-    parameters:
-      - 1.0
-      - 10.0
+  force_continuous_object_qoi: True

--- a/tests/config/conf_wrong_from_samplers_load_sampler_003.yml
+++ b/tests/config/conf_wrong_from_samplers_load_sampler_003.yml
@@ -7,7 +7,7 @@ from_samplers:
     name: lognormal
     parameters:
       - 1.0
-      - '10.0'
+      - "10.0"
   volume_sampler:
     name: lognormal
     parameters:

--- a/tests/config/conf_wrong_from_samplers_load_sampler_004.yml
+++ b/tests/config/conf_wrong_from_samplers_load_sampler_004.yml
@@ -1,4 +1,18 @@
 # Specify input
+from_samplers:
+  n_objects: 200
+  n_mapped_ranks: 2
+  communication_degree: 20
+  load_sampler:
+    name: lognorma
+    parameters:
+      - 1.0
+      - 10.0
+  volume_sampler:
+    name: lognormal
+    parameters:
+      - 1.0
+      - 10.0
 
 # Specify work model
 work_model:
@@ -19,10 +33,9 @@ algorithm:
     transfer_strategy: Recursive
     criterion: Tempered
     max_objects_per_transfer: 8
-    deterministic_transfer: true
+    deterministic_transfer: True
 
 # Specify output
-terminal_background: light
 output_dir: ../../../output
 output_file_stem: output_file
 n_ranks: 4
@@ -33,20 +46,4 @@ LBAF_Viz:
   object_jitter: 0.5
   rank_qoi: None
   object_qoi: None
-  force_continuous_object_qoi: true
-
-# Other
-from_samplers:
-  n_objects: 200
-  n_mapped_ranks: 2
-  communication_degree: 20
-  load_sampler:
-    name: lognorma
-    parameters:
-      - 1.0
-      - 10.0
-  volume_sampler:
-    name: lognormal
-    parameters:
-      - 1.0
-      - 10.0
+  force_continuous_object_qoi: True

--- a/tests/config/conf_wrong_from_samplers_load_sampler_005.yml
+++ b/tests/config/conf_wrong_from_samplers_load_sampler_005.yml
@@ -1,4 +1,18 @@
 # Specify input
+from_samplers:
+  n_objects: 200
+  n_mapped_ranks: 2
+  communication_degree: 20
+  load_samplers:
+    name: lognormal
+    parameters:
+      - 1.0
+      - 10.0
+  volume_sampler:
+    name: lognormal
+    parameters:
+      - 1.0
+      - 10.0
 
 # Specify work model
 work_model:
@@ -19,10 +33,9 @@ algorithm:
     transfer_strategy: Recursive
     criterion: Tempered
     max_objects_per_transfer: 8
-    deterministic_transfer: true
+    deterministic_transfer: True
 
 # Specify output
-terminal_background: light
 output_dir: ../../../output
 output_file_stem: output_file
 n_ranks: 4
@@ -33,20 +46,4 @@ LBAF_Viz:
   object_jitter: 0.5
   rank_qoi: None
   object_qoi: None
-  force_continuous_object_qoi: true
-
-# Other
-from_samplers:
-  n_objects: 200
-  n_mapped_ranks: 2
-  communication_degree: 20
-  load_samplers:
-    name: lognormal
-    parameters:
-      - 1.0
-      - 10.0
-  volume_sampler:
-    name: lognormal
-    parameters:
-      - 1.0
-      - 10.0
+  force_continuous_object_qoi: True

--- a/tests/config/conf_wrong_missing_from_data_param.yml
+++ b/tests/config/conf_wrong_missing_from_data_param.yml
@@ -21,10 +21,9 @@ algorithm:
     transfer_strategy: Recursive
     criterion: Tempered
     max_objects_per_transfer: 8
-    deterministic_transfer: true
+    deterministic_transfer: True
 
 # Specify output
-terminal_background: light
 output_dir: ../../../output
 output_file_stem: output_file
 n_ranks: 4
@@ -35,4 +34,4 @@ LBAF_Viz:
   object_jitter: 0.5
   rank_qoi: None
   object_qoi: None
-  force_continuous_object_qoi: true
+  force_continuous_object_qoi: True

--- a/tests/config/conf_wrong_no_data_and_sampling.yml
+++ b/tests/config/conf_wrong_no_data_and_sampling.yml
@@ -19,10 +19,9 @@ algorithm:
     transfer_strategy: Recursive
     criterion: Tempered
     max_objects_per_transfer: 8
-    deterministic_transfer: true
+    deterministic_transfer: True
 
 # Specify output
-terminal_background: light
 output_dir: ../../../output
 output_file_stem: output_file
 n_ranks: 4
@@ -33,4 +32,4 @@ LBAF_Viz:
   object_jitter: 0.5
   rank_qoi: None
   object_qoi: None
-  force_continuous_object_qoi: true
+  force_continuous_object_qoi: True

--- a/tests/config/conf_wrong_phase_ids_str_001.yml
+++ b/tests/config/conf_wrong_phase_ids_str_001.yml
@@ -22,10 +22,9 @@ algorithm:
     transfer_strategy: Recursive
     criterion: Tempered
     max_objects_per_transfer: 8
-    deterministic_transfer: true
+    deterministic_transfer: True
 
 # Specify output
-terminal_background: light
 output_dir: ../../../output
 output_file_stem: output_file
 n_ranks: 4
@@ -36,4 +35,4 @@ LBAF_Viz:
   object_jitter: 0.5
   rank_qoi: None
   object_qoi: None
-  force_continuous_object_qoi: true
+  force_continuous_object_qoi: True

--- a/tests/config/conf_wrong_work_model_missing.yml
+++ b/tests/config/conf_wrong_work_model_missing.yml
@@ -18,7 +18,7 @@ algorithm:
     transfer_strategy: Recursive
     criterion: Tempered
     max_objects_per_transfer: 8
-    deterministic_transfer: true
+    deterministic_transfer: True
 
 # Specify output
 output_dir: ../../../output
@@ -31,4 +31,4 @@ LBAF_Viz:
   object_jitter: 0.5
   rank_qoi: None
   object_qoi: None
-  force_continuous_object_qoi: true
+  force_continuous_object_qoi: True

--- a/tests/config/conf_wrong_work_model_name.yml
+++ b/tests/config/conf_wrong_work_model_name.yml
@@ -24,7 +24,7 @@ algorithm:
     transfer_strategy: Recursive
     criterion: Tempered
     max_objects_per_transfer: 8
-    deterministic_transfer: true
+    deterministic_transfer: True
 
 # Specify output
 output_dir: ../../../output
@@ -37,4 +37,4 @@ LBAF_Viz:
   object_jitter: 0.5
   rank_qoi: None
   object_qoi: None
-  force_continuous_object_qoi: true
+  force_continuous_object_qoi: True

--- a/tests/config/conf_wrong_work_model_parameters_missing.yml
+++ b/tests/config/conf_wrong_work_model_parameters_missing.yml
@@ -23,7 +23,7 @@ algorithm:
     transfer_strategy: Recursive
     criterion: Tempered
     max_objects_per_transfer: 8
-    deterministic_transfer: true
+    deterministic_transfer: True
 
 # Specify output
 output_dir: ../../../output
@@ -36,4 +36,4 @@ LBAF_Viz:
   object_jitter: 0.5
   rank_qoi: None
   object_qoi: None
-  force_continuous_object_qoi: true
+  force_continuous_object_qoi: True

--- a/tests/config/conf_wrong_work_model_parameters_type.yml
+++ b/tests/config/conf_wrong_work_model_parameters_type.yml
@@ -24,7 +24,7 @@ algorithm:
     transfer_strategy: Recursive
     criterion: Tempered
     max_objects_per_transfer: 8
-    deterministic_transfer: true
+    deterministic_transfer: True
 
 # Specify output
 output_dir: ../../../output
@@ -37,4 +37,4 @@ LBAF_Viz:
   object_jitter: 0.5
   rank_qoi: None
   object_qoi: None
-  force_continuous_object_qoi: true
+  force_continuous_object_qoi: True

--- a/tests/test_lbs_object.py
+++ b/tests/test_lbs_object.py
@@ -141,7 +141,7 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(err.exception.args[0], "user_defined: [] is of type <class 'list'>. Must be <class 'dict'>.")
 
         with self.assertRaises(TypeError) as err:
-            Object(i=0, load=2.5, r_id=0, comm=self.oc, user_defined="a")
+            Object(i=0, load=2.5, r_id=0, comm=self.oc, user_defined='a')
         self.assertEqual(err.exception.args[0], "user_defined: a is of type <class 'str'>. Must be <class 'dict'>.")
 
         with self.assertRaises(TypeError) as err:

--- a/tests/test_schema_validator.py
+++ b/tests/test_schema_validator.py
@@ -26,7 +26,7 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(True, is_valid)
 
     def test_schema_validator_valid_uncompressed_001(self):
-        with open(os.path.join(self.data_dir, 'valid_schema_uncompressed_001.json'), "r", encoding="utf-8") as uncompr_json_file:
+        with open(os.path.join(self.data_dir, 'valid_schema_uncompressed_001.json'), 'r', encoding="utf-8") as uncompr_json_file:
             uncompr_txt = uncompr_json_file.read()
         vjs_json = json.loads(uncompr_txt)
         is_valid = SchemaValidator(schema_type="LBDatafile").is_valid(schema_to_validate=vjs_json)
@@ -35,14 +35,14 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(True, is_valid)
 
     def test_schema_validator_invalid_001(self):
-        with open(os.path.join(self.data_dir, "invalid_schema_001.json"), "r", encoding="utf-8") as invalid_json_schema:
+        with open(os.path.join(self.data_dir, "invalid_schema_001.json"), 'r', encoding="utf-8") as invalid_json_schema:
             vjs_str = invalid_json_schema.read()
             vjs_json = json.loads(vjs_str)
         is_valid = SchemaValidator(schema_type="LBDatafile").is_valid(schema_to_validate=vjs_json)
         self.assertEqual(False, is_valid)
 
     def test_schema_validator_invalid_002(self):
-        with open(os.path.join(self.data_dir, "invalid_schema_002.json"), "r", encoding="utf-8") as invalid_json_schema:
+        with open(os.path.join(self.data_dir, "invalid_schema_002.json"), 'r', encoding="utf-8") as invalid_json_schema:
             vjs_str = invalid_json_schema.read()
             vjs_json = json.loads(vjs_str)
         is_valid = SchemaValidator(schema_type="LBDatafile").is_valid(schema_to_validate=vjs_json)


### PR DESCRIPTION
Fixes #347 

- This pull request remove the terminal_background option from the configuration and from the existing configuration files.
 Note: we might need to check again for #154 . If the problem of #154 occurs again it should be resolved by client user by changing the terminal settings. That is because a logged message is written to the console after a "clear color" so it should use the default user terminal color. If color is bad then change the client user terminal text color
- terminal_background option has also been removed from rst docs and from the schema defined in the ConfigurationValidator class
- Additionnaly it improves the configuration_upgrader.py script to keep comments at the top of the file if defined
-  It also adds the display of an error message and exits lbaf if running with Python 3.9 in case save_meshes is True in configuration file from the Visualizer. This is to explicitly say that this error is known.
- LBAF_app refactoring for more readability : load arguments inside a dedicated method
- Fix some configuration parameters not classified in sections in configuration files when using configuration upgrader