### PR TITLE
#353: Automatically set n_ranks based on files found by stem

### DIFF
--- a/config/acceptance_tests/conf.yaml
+++ b/config/acceptance_tests/conf.yaml
@@ -31,4 +31,3 @@ algorithm:
 logging_level: info
 output_dir: ../../output
 output_file_stem: output_file
-n_ranks: 4

--- a/config/acceptance_tests/step.yaml
+++ b/config/acceptance_tests/step.yaml
@@ -30,4 +30,3 @@ algorithm:
 log_to_file: ../../output/log.txt
 output_dir: ../../output
 output_file_stem: output_file
-n_ranks: 32

--- a/config/challenging-toy-hundreds-tasks.yaml
+++ b/config/challenging-toy-hundreds-tasks.yaml
@@ -32,7 +32,6 @@ algorithm:
 # Specify output
 output_dir: ../output
 output_file_stem: output_file
-n_ranks: 64
 LBAF_Viz:
   x_ranks: 8
   y_ranks: 8

--- a/config/conf.yaml
+++ b/config/conf.yaml
@@ -86,7 +86,6 @@ algorithm:
 # Specify output
 output_dir: ../output
 output_file_stem: output_file
-n_ranks: 4
 LBAF_Viz:
   x_ranks: 2
   y_ranks: 2

--- a/config/every20phases.yaml
+++ b/config/every20phases.yaml
@@ -38,7 +38,6 @@ algorithm:
 # Specify output
 output_dir: ../output
 output_file_stem: output_file
-n_ranks: 32
 LBAF_Viz:
   x_ranks: 8
   y_ranks: 4

--- a/config/step.yaml
+++ b/config/step.yaml
@@ -30,7 +30,6 @@ algorithm:
 # Specify output
 output_dir: ../output
 output_file_stem: output_file
-n_ranks: 32
 LBAF_Viz:
   x_ranks: 8
   y_ranks: 4

--- a/config/user-defined-memory-toy-problem.yaml
+++ b/config/user-defined-memory-toy-problem.yaml
@@ -32,7 +32,6 @@ algorithm:
 # Specify output
 output_dir: ../output
 output_file_stem: output_file
-n_ranks: 4
 LBAF_Viz:
   x_ranks: 2
   y_ranks: 2

--- a/docs/pages/configuration.rst
+++ b/docs/pages/configuration.rst
@@ -99,7 +99,6 @@ Example configuration
     generate_multimedia: False
     output_dir: ../../../output
     output_file_stem: output_file
-    n_ranks: 4
     generate_meshes:
       x_ranks: 2
       y_ranks: 2

--- a/docs/pages/testing.rst
+++ b/docs/pages/testing.rst
@@ -89,7 +89,6 @@ Acceptance Test Configuration
   #logging_level: debug
   #overwrite_validator: False
   #check_schema: False
-  n_ranks: 4
   logging_level: info
   output_dir: /__w/LB-analysis-framework/LB-analysis-framework/output
   output_file_stem: output_file
@@ -140,7 +139,6 @@ Stepper Test Configuration
   generate_multimedia: False
   output_dir: /__w/LB-analysis-framework/LB-analysis-framework/output
   output_file_stem: output_file
-  n_ranks: 32
   generate_meshes:
     x_ranks: 8
     y_ranks: 4

--- a/src/lbaf/Applications/LBAF_app.py
+++ b/src/lbaf/Applications/LBAF_app.py
@@ -446,7 +446,6 @@ class Application:
 
         # Generate meshes and multimedia when requested
         if self.__parameters.grid_size:
-
             n_ranks = reader.n_ranks if reader is not None else self.__parameters.n_ranks
             # Verify grid size consistency
             if math.prod(self.__parameters.grid_size) < n_ranks:

--- a/src/lbaf/Applications/LBAF_app.py
+++ b/src/lbaf/Applications/LBAF_app.py
@@ -316,6 +316,8 @@ class Application:
 
         reader = None # type: Optional(LoadReader)
 
+        n_ranks = None
+
         # Populate phase depending on chosen mechanism
         if self.__parameters.data_stem:
             # Populate phase from log files and store number of objects
@@ -327,6 +329,8 @@ class Application:
                 logger=self.__logger,
                 file_suffix=file_suffix if file_suffix is not None else "json",
                 check_schema=check_schema)
+            # retrieve n_ranks
+            n_ranks = reader.n_ranks
 
             # Iterate over phase IDs
             for phase_id in self.__parameters.phase_ids:
@@ -340,6 +344,7 @@ class Application:
                 phase.populate_from_log(phase_id)
                 phases[phase_id] = phase
         else:
+            n_ranks = self.__parameters.n_ranks
             phase_id = 0
             phase = Phase(self.__logger, phase_id)
             phase.populate_from_samplers(
@@ -385,8 +390,8 @@ class Application:
                 for k in ("alpha", "beta", "gamma")
             ]
             n_a, w_min_max, a_min_max = compute_min_max_arrangements_work(
-                objects, alpha, beta, gamma, self.__parameters.n_ranks)
-            if n_a != self.__parameters.n_ranks ** len(objects):
+                objects, alpha, beta, gamma, n_ranks)
+            if n_a != n_ranks ** len(objects):
                 self.__logger.error("Incorrect number of possible arrangements with repetition")
                 sys.excepthook = exc_handler
                 raise SystemExit(1)
@@ -446,7 +451,6 @@ class Application:
 
         # Generate meshes and multimedia when requested
         if self.__parameters.grid_size:
-            n_ranks = reader.n_ranks if reader is not None else self.__parameters.n_ranks
             # Verify grid size consistency
             if math.prod(self.__parameters.grid_size) < n_ranks:
                 self.__logger.error("Grid size: {self.__parameters.grid_size} < {n_ranks}")

--- a/src/lbaf/Execution/lbsAlgorithmBase.py
+++ b/src/lbaf/Execution/lbsAlgorithmBase.py
@@ -120,17 +120,27 @@ class AlgorithmBase:
         for object_qoi_name in tuple({"load", self.__object_qoi}):
             if not object_qoi_name:
                 continue
-            distributions.setdefault(f"object {object_qoi_name}", []).append(
-                {o.get_id(): getattr(o, f"get_{object_qoi_name}")()
-                 for o in self._rebalanced_phase.get_objects()})
+            try:
+                distributions.setdefault(f"object {object_qoi_name}", []).append(
+                    {o.get_id(): getattr(o, f"get_{object_qoi_name}")()
+                    for o in self._rebalanced_phase.get_objects()})
+            except AttributeError as err:
+                self._logger.error(f"Invalid object_qoi name \"{object_qoi_name}\"")
+                sys.excepthook = exc_handler
+                raise SystemExit(1) from err
 
         # Create or update distributions of rank quantities of interest
         for rank_qoi_name in tuple({"objects", "load", self.__rank_qoi}):
             if not rank_qoi_name or rank_qoi_name == "work":
                 continue
-            distributions.setdefault(f"rank {rank_qoi_name}", []).append(
-                [getattr(p, f"get_{rank_qoi_name}")()
-                 for p in self._rebalanced_phase.get_ranks()])
+            try:
+                distributions.setdefault(f"rank {rank_qoi_name}", []).append(
+                    [getattr(p, f"get_{rank_qoi_name}")()
+                    for p in self._rebalanced_phase.get_ranks()])
+            except AttributeError as err:
+                self._logger.error(f"Invalid rank_qoi name \"{rank_qoi_name}\"")
+                sys.excepthook = exc_handler
+                raise SystemExit(1) from err
         distributions.setdefault("rank work", []).append(
             [self._work_model.compute(p) for p in self._rebalanced_phase.get_ranks()])
 

--- a/src/lbaf/IO/lbsConfigurationValidator.py
+++ b/src/lbaf/IO/lbsConfigurationValidator.py
@@ -67,10 +67,6 @@ class ConfigurationValidator:
                 Optional("phase_id"): int,
                 Optional("parameters"): dict},
            "output_file_stem": str,
-            "n_ranks": And(
-                int,
-                lambda x: x > 0,
-                error="Should be of type 'int' and > 0"),
             Optional("brute_force_optimization"): bool,
             Optional("overwrite_validator"): bool,
             Optional("check_schema"): bool,
@@ -111,6 +107,10 @@ class ConfigurationValidator:
                  Regex(r"^[0-9]+-[0-9]+$", error="Should be of type 'str' like '0-100'"))
              })
         self.__from_samplers = Schema({
+            "n_ranks": And(
+                int,
+                lambda x: x > 0,
+                error="Should be of type 'int' and > 0"),
             "n_objects": And(int, lambda x: x > 0,
                              error="Should be of type 'int' and > 0"),
             "n_mapped_ranks": And(int, lambda x: x >= 0,
@@ -188,9 +188,9 @@ class ConfigurationValidator:
             "work model": ["work_model"],
             "algorithm": ["brute_force_optimization", "algorithm"],
             "output": [
-                "logging_level", "log_to_file", "overwrite_validator",
-                "generate_multimedia", "output_dir", "output_file_stem", "n_ranks",
-                "LBAF_Viz", "write_JSON"
+                "logging_level", "log_to_file", "overwrite_validator", "check_schema", "terminal_background",
+                "generate_multimedia", "output_dir", "output_file_stem",
+                "LBAF_Viz"
             ]
         }
 

--- a/src/lbaf/IO/lbsVTDataReader.py
+++ b/src/lbaf/IO/lbsVTDataReader.py
@@ -12,7 +12,6 @@ from ..Model.lbsObject import Object
 from ..Model.lbsObjectCommunicator import ObjectCommunicator
 from ..Model.lbsRank import Rank
 from ..Utils.exception_handler import exc_handler
-from ..Utils.path import abspath
 
 
 class LoadReader:
@@ -68,7 +67,7 @@ class LoadReader:
 
         # Perform sanity check on number of loaded phases
         l = len(next(iter(self.__vt_data.values())).get("phases"))
-        if not (all(len(v.get("phases")) == l for v in self.__vt_data.values())):
+        if not all(len(v.get("phases")) == l for v in self.__vt_data.values()):
             self.__logger.error(
                 "Not all JSON files have the same number of phases")
             sys.excepthook = exc_handler
@@ -170,7 +169,7 @@ class LoadReader:
 
         # Add communications to the object
         rank_comm = {}
-        communications = phase.get("communications")
+        communications = phase.get("communications") # pylint:disable=W0631:undefined-loop-variable
         if communications:
             for num, comm in enumerate(communications):
                 # Retrieve communication attributes
@@ -211,7 +210,7 @@ class LoadReader:
         rank_blocks, task_user_defined = {}, {}
 
         # Iterate over tasks
-        for task in phase.get("tasks", []):
+        for task in phase.get("tasks", []): # pylint:disable=W0631:undefined-loop-variable
             # Retrieve required values
             task_entity = task.get("entity")
             task_id = task_entity.get("id")

--- a/src/lbaf/IO/lbsVTDataReader.py
+++ b/src/lbaf/IO/lbsVTDataReader.py
@@ -12,6 +12,7 @@ from ..Model.lbsObject import Object
 from ..Model.lbsObjectCommunicator import ObjectCommunicator
 from ..Model.lbsRank import Rank
 from ..Utils.exception_handler import exc_handler
+from ..Utils.path import abspath
 
 
 class LoadReader:
@@ -30,17 +31,14 @@ class LoadReader:
         "CollectionToNodeBcast": 5,
         "NodeToCollectionBcast": 6,
         "CollectiveToCollectionBcast": 7,
-    }
+    }  
 
-    def __init__(self, file_prefix: str, n_ranks: int, logger: Logger, file_suffix: str = "json", check_schema=True):
+    def __init__(self, file_prefix: str, logger: Logger, file_suffix: str = "json", check_schema=True):
         # The base directory and file name for the log files
         self.__file_prefix = file_prefix
 
         # Data files(data loading) suffix
         self.__file_suffix = file_suffix
-
-        # Number of ranks
-        self.__n_ranks = n_ranks
 
         # Assign logger to instance variable
         self.__logger = logger
@@ -53,13 +51,20 @@ class LoadReader:
             from ..imported.JSON_data_files_validator import SchemaValidator as sv # pylint:disable=C0415:import-outside-toplevel
             LoadReader.SCHEMA_VALIDATOR_CLASS = sv
 
-        # Load vt data concurrently
+        # load vt data at rank 0
         self.__vt_data = {}
-        with Pool(context=get_context("fork")) as pool:
-            results = pool.imap_unordered(
-                self._load_vt_file, range(self.__n_ranks))
-            for rank, decompressed_dict in results:
-                self.__vt_data[rank] = decompressed_dict
+        rank_0, vt_data_0 = self._load_vt_file(0)
+        self.__vt_data[rank_0] = vt_data_0
+
+        # determine the number of ranks
+        self.n_ranks = self._get_n_ranks()
+        if self.n_ranks > 1:
+            # Load vt data concurrently from rank 1 to n_ranks
+            with Pool(context=get_context("fork")) as pool:
+                results = pool.imap_unordered(
+                    self._load_vt_file, range(1, self.n_ranks))
+                for rank, decompressed_dict in results:
+                    self.__vt_data[rank] = decompressed_dict
 
         # Perform sanity check on number of loaded phases
         l = len(next(iter(self.__vt_data.values())).get("phases"))
@@ -68,6 +73,27 @@ class LoadReader:
                 "Not all JSON files have the same number of phases")
             sys.excepthook = exc_handler
             raise SystemExit(1)
+
+    def _get_n_ranks(self):
+        """Determine the number of ranks by
+        - reading the first loaded vt data file metadata (Requires first data file loaded)
+        - then (if not available) counting the number of files found in the data directory.
+        """
+
+        if len(self.__vt_data) > 0:
+            metadata = self.__vt_data.get(0).get('metadata')
+            if metadata is not None:
+                shared_node = metadata.get('shared_node')
+                if shared_node is not None:
+                    num_nodes = shared_node.get('num_nodes')
+                    if num_nodes is not None:
+                        return num_nodes
+        else:
+            self.__logger.warn('First vt data file has not been loaded. Cannot get n_ranks from vt data')
+
+        # or default count files in data dir
+        data_dir = f"{os.sep}".join(self.__file_prefix.split(os.sep)[:-1])
+        return len([name for name in os.listdir(data_dir)])
 
     def _get_rank_file_name(self, rank_id: int):
         # Convenience method also used by test harness
@@ -117,6 +143,7 @@ class LoadReader:
 
     def _populate_rank(self, phase_id: int, rank_id: int) -> tuple:
         """ Populate rank and its communicator in phase using the JSON content."""
+
         # Seek phase with given ID
         phase_id_found = False
         for phase in self.__vt_data.get(rank_id).get("phases"):
@@ -238,12 +265,13 @@ class LoadReader:
 
     def populate_phase(self, phase_id: int) -> list:
         """ Populate phase using the JSON content."""
+
         # Create storage for ranks
-        ranks = [None] * self.__n_ranks
+        ranks = [None] * self.n_ranks
         communications = {}
 
         # Iterate over all ranks
-        for rank_id in range(self.__n_ranks):
+        for rank_id in range(self.n_ranks):
             # Read data for given phase and assign it to rank
             ranks[rank_id], rank_comm = self._populate_rank(phase_id, rank_id)
 

--- a/src/lbaf/IO/lbsVTDataReader.py
+++ b/src/lbaf/IO/lbsVTDataReader.py
@@ -30,7 +30,7 @@ class LoadReader:
         "CollectionToNodeBcast": 5,
         "NodeToCollectionBcast": 6,
         "CollectiveToCollectionBcast": 7,
-    }  
+    }
 
     def __init__(self, file_prefix: str, logger: Logger, file_suffix: str = "json", check_schema=True):
         # The base directory and file name for the log files

--- a/tests/config/conf_correct_001.yml
+++ b/tests/config/conf_correct_001.yml
@@ -29,7 +29,6 @@ algorithm:
 # Specify output
 output_dir: ../../output
 output_file_stem: output_file
-n_ranks: 4
 LBAF_Viz:
   x_ranks: 2
   y_ranks: 2

--- a/tests/config/conf_correct_002.yml
+++ b/tests/config/conf_correct_002.yml
@@ -39,7 +39,6 @@ algorithm:
 # Specify output
 output_dir: ../../../output
 output_file_stem: output_file
-n_ranks: 4
 LBAF_Viz:
   x_ranks: 2
   y_ranks: 2

--- a/tests/config/conf_correct_002.yml
+++ b/tests/config/conf_correct_002.yml
@@ -1,6 +1,7 @@
 # Specify input
 from_samplers:
   n_objects: 200
+  n_ranks: 4
   n_mapped_ranks: 2
   communication_degree: 20
   load_sampler:

--- a/tests/config/conf_correct_003.yml
+++ b/tests/config/conf_correct_003.yml
@@ -31,7 +31,6 @@ algorithm:
 logging_level: debug
 output_dir: ../../../output
 output_file_stem: output_file
-n_ranks: 4
 LBAF_Viz:
   x_ranks: 2
   y_ranks: 2

--- a/tests/config/conf_correct_brute_force.yml
+++ b/tests/config/conf_correct_brute_force.yml
@@ -22,7 +22,6 @@ algorithm:
 logging_level: debug
 output_dir: ../../../output
 output_file_stem: output_file
-n_ranks: 4
 LBAF_Viz:
   x_ranks: 2
   y_ranks: 2

--- a/tests/config/conf_correct_from_data_min_config.yml
+++ b/tests/config/conf_correct_from_data_min_config.yml
@@ -19,7 +19,6 @@ algorithm:
 
 # Specify output
 output_file_stem: output_file
-n_ranks: 4
 LBAF_Viz:
   x_ranks: 2
   y_ranks: 2

--- a/tests/config/conf_correct_from_samplers_no_ll.yml
+++ b/tests/config/conf_correct_from_samplers_no_ll.yml
@@ -39,7 +39,6 @@ algorithm:
 # Specify output
 output_dir: ../../../output
 output_file_stem: output_file
-n_ranks: 4
 LBAF_Viz:
   x_ranks: 2
   y_ranks: 2

--- a/tests/config/conf_correct_from_samplers_no_ll.yml
+++ b/tests/config/conf_correct_from_samplers_no_ll.yml
@@ -1,6 +1,7 @@
 # Specify input
 from_samplers:
   n_objects: 200
+  n_ranks: 4
   n_mapped_ranks: 2
   communication_degree: 20
   load_sampler:

--- a/tests/config/conf_correct_phase_ids_str_001.yml
+++ b/tests/config/conf_correct_phase_ids_str_001.yml
@@ -28,7 +28,6 @@ algorithm:
 # Specify output
 output_dir: ../../../output
 output_file_stem: output_file
-n_ranks: 4
 LBAF_Viz:
   x_ranks: 2
   y_ranks: 2

--- a/tests/config/conf_vt_writer_stepper_test.yml
+++ b/tests/config/conf_vt_writer_stepper_test.yml
@@ -30,7 +30,6 @@ algorithm:
 # Specify output
 output_dir: ../output/vt_writer_stepper_test
 output_file_stem: output_file
-n_ranks: 32
 write_JSON:
   compressed: True
   suffix: json

--- a/tests/config/conf_wrong_algorithm_invalid_001.yml
+++ b/tests/config/conf_wrong_algorithm_invalid_001.yml
@@ -21,7 +21,6 @@ algorithm:
 
 # Specify output
 output_file_stem: output_file
-n_ranks: 4
 LBAF_Viz:
   x_ranks: 2
   y_ranks: 2

--- a/tests/config/conf_wrong_algorithm_invalid_002.yml
+++ b/tests/config/conf_wrong_algorithm_invalid_002.yml
@@ -27,7 +27,6 @@ algorithm:
 # Specify output
 output_dir: ../../../output
 output_file_stem: output_file
-n_ranks: 4
 LBAF_Viz:
   x_ranks: 2
   y_ranks: 2

--- a/tests/config/conf_wrong_data_and_sampling.yml
+++ b/tests/config/conf_wrong_data_and_sampling.yml
@@ -42,7 +42,6 @@ algorithm:
 # Specify output
 output_dir: ../../../output
 output_file_stem: output_file
-n_ranks: 4
 LBAF_Viz:
   x_ranks: 2
   y_ranks: 2

--- a/tests/config/conf_wrong_data_and_sampling.yml
+++ b/tests/config/conf_wrong_data_and_sampling.yml
@@ -5,6 +5,7 @@ from_data:
     - 0
 from_samplers:
   n_objects: 200
+  n_ranks: 4
   n_mapped_ranks: 2
   communication_degree: 20
   load_sampler:

--- a/tests/config/conf_wrong_from_data_phase_name.yml
+++ b/tests/config/conf_wrong_from_data_phase_name.yml
@@ -26,7 +26,6 @@ algorithm:
 # Specify output
 output_dir: ../../../output
 output_file_stem: output_file
-n_ranks: 4
 LBAF_Viz:
   x_ranks: 2
   y_ranks: 2

--- a/tests/config/conf_wrong_from_data_phase_type.yml
+++ b/tests/config/conf_wrong_from_data_phase_type.yml
@@ -28,7 +28,6 @@ algorithm:
 # Specify output
 output_dir: ../../../output
 output_file_stem: output_file
-n_ranks: 4
 LBAF_Viz:
   x_ranks: 2
   y_ranks: 2

--- a/tests/config/conf_wrong_from_samplers_load_sampler_001.yml
+++ b/tests/config/conf_wrong_from_samplers_load_sampler_001.yml
@@ -39,7 +39,6 @@ algorithm:
 # Specify output
 output_dir: ../../../output
 output_file_stem: output_file
-n_ranks: 4
 LBAF_Viz:
   x_ranks: 2
   y_ranks: 2

--- a/tests/config/conf_wrong_from_samplers_load_sampler_001.yml
+++ b/tests/config/conf_wrong_from_samplers_load_sampler_001.yml
@@ -1,6 +1,7 @@
 # Specify input
 from_samplers:
   n_objects: 200
+  n_ranks: 4
   n_mapped_ranks: 2
   communication_degree: 20
   load_sampler:

--- a/tests/config/conf_wrong_from_samplers_load_sampler_002.yml
+++ b/tests/config/conf_wrong_from_samplers_load_sampler_002.yml
@@ -37,7 +37,6 @@ algorithm:
 # Specify output
 output_dir: ../../../output
 output_file_stem: output_file
-n_ranks: 4
 LBAF_Viz:
   x_ranks: 2
   y_ranks: 2

--- a/tests/config/conf_wrong_from_samplers_load_sampler_002.yml
+++ b/tests/config/conf_wrong_from_samplers_load_sampler_002.yml
@@ -1,6 +1,7 @@
 # Specify input
 from_samplers:
   n_objects: 200
+  n_ranks: 4
   n_mapped_ranks: 2
   communication_degree: 20
   load_sampler:

--- a/tests/config/conf_wrong_from_samplers_load_sampler_003.yml
+++ b/tests/config/conf_wrong_from_samplers_load_sampler_003.yml
@@ -38,7 +38,6 @@ algorithm:
 # Specify output
 output_dir: ../../../output
 output_file_stem: output_file
-n_ranks: 4
 LBAF_Viz:
   x_ranks: 2
   y_ranks: 2

--- a/tests/config/conf_wrong_from_samplers_load_sampler_003.yml
+++ b/tests/config/conf_wrong_from_samplers_load_sampler_003.yml
@@ -1,6 +1,7 @@
 # Specify input
 from_samplers:
   n_objects: 200
+  n_ranks: 4
   n_mapped_ranks: 2
   communication_degree: 20
   load_sampler:

--- a/tests/config/conf_wrong_from_samplers_load_sampler_004.yml
+++ b/tests/config/conf_wrong_from_samplers_load_sampler_004.yml
@@ -38,7 +38,6 @@ algorithm:
 # Specify output
 output_dir: ../../../output
 output_file_stem: output_file
-n_ranks: 4
 LBAF_Viz:
   x_ranks: 2
   y_ranks: 2

--- a/tests/config/conf_wrong_from_samplers_load_sampler_005.yml
+++ b/tests/config/conf_wrong_from_samplers_load_sampler_005.yml
@@ -38,7 +38,6 @@ algorithm:
 # Specify output
 output_dir: ../../../output
 output_file_stem: output_file
-n_ranks: 4
 LBAF_Viz:
   x_ranks: 2
   y_ranks: 2

--- a/tests/config/conf_wrong_from_samplers_load_sampler_005.yml
+++ b/tests/config/conf_wrong_from_samplers_load_sampler_005.yml
@@ -1,6 +1,7 @@
 # Specify input
 from_samplers:
   n_objects: 200
+  n_ranks: 4
   n_mapped_ranks: 2
   communication_degree: 20
   load_samplers:

--- a/tests/config/conf_wrong_missing_from_data_param.yml
+++ b/tests/config/conf_wrong_missing_from_data_param.yml
@@ -26,7 +26,6 @@ algorithm:
 # Specify output
 output_dir: ../../../output
 output_file_stem: output_file
-n_ranks: 4
 LBAF_Viz:
   x_ranks: 2
   y_ranks: 2

--- a/tests/config/conf_wrong_no_data_and_sampling.yml
+++ b/tests/config/conf_wrong_no_data_and_sampling.yml
@@ -24,7 +24,6 @@ algorithm:
 # Specify output
 output_dir: ../../../output
 output_file_stem: output_file
-n_ranks: 4
 LBAF_Viz:
   x_ranks: 2
   y_ranks: 2

--- a/tests/config/conf_wrong_phase_ids_str_001.yml
+++ b/tests/config/conf_wrong_phase_ids_str_001.yml
@@ -27,7 +27,6 @@ algorithm:
 # Specify output
 output_dir: ../../../output
 output_file_stem: output_file
-n_ranks: 4
 LBAF_Viz:
   x_ranks: 2
   y_ranks: 2

--- a/tests/config/conf_wrong_work_model_missing.yml
+++ b/tests/config/conf_wrong_work_model_missing.yml
@@ -23,7 +23,6 @@ algorithm:
 # Specify output
 output_dir: ../../../output
 output_file_stem: output_file
-n_ranks: 4
 LBAF_Viz:
   x_ranks: 2
   y_ranks: 2

--- a/tests/config/conf_wrong_work_model_name.yml
+++ b/tests/config/conf_wrong_work_model_name.yml
@@ -29,7 +29,6 @@ algorithm:
 # Specify output
 output_dir: ../../../output
 output_file_stem: output_file
-n_ranks: 4
 LBAF_Viz:
   x_ranks: 2
   y_ranks: 2

--- a/tests/config/conf_wrong_work_model_parameters_missing.yml
+++ b/tests/config/conf_wrong_work_model_parameters_missing.yml
@@ -28,7 +28,6 @@ algorithm:
 # Specify output
 output_dir: ../../../output
 output_file_stem: output_file
-n_ranks: 4
 LBAF_Viz:
   x_ranks: 2
   y_ranks: 2

--- a/tests/config/conf_wrong_work_model_parameters_type.yml
+++ b/tests/config/conf_wrong_work_model_parameters_type.yml
@@ -29,7 +29,6 @@ algorithm:
 # Specify output
 output_dir: ../../../output
 output_file_stem: output_file
-n_ranks: 4
 LBAF_Viz:
   x_ranks: 2
   y_ranks: 2

--- a/tests/test_lbs_phase.py
+++ b/tests/test_lbs_phase.py
@@ -14,7 +14,7 @@ class TestConfig(unittest.TestCase):
         self.data_dir = os.path.join(PROJECT_PATH, "tests", "data")
         self.logger = logging.getLogger()
         self.file_prefix = os.path.join(self.data_dir, "synthetic_lb_data_compressed", "data")
-        self.reader = LoadReader(file_prefix=self.file_prefix, n_ranks=4, logger=self.logger, file_suffix="json")
+        self.reader = LoadReader(file_prefix=self.file_prefix, logger=self.logger, file_suffix="json")
         self.phase = Phase(self.logger, 0, reader=self.reader)
 
     def test_lbs_phase_initialization(self):

--- a/tests/test_lbs_vt_data_reader.py
+++ b/tests/test_lbs_vt_data_reader.py
@@ -16,7 +16,7 @@ class TestConfig(unittest.TestCase):
         self.data_dir = os.path.join(PROJECT_PATH, "tests", "data")
         self.file_prefix = os.path.join(self.data_dir, "synthetic_lb_data", "data")
         self.logger = logging.getLogger()
-        self.lr = LoadReader(file_prefix=self.file_prefix, n_ranks=4, logger=self.logger, file_suffix="json")
+        self.lr = LoadReader(file_prefix=self.file_prefix, logger=self.logger, file_suffix="json")
         self.rank_comm = [
             {
                 5: {"sent": [], "received": [{"from": 0, "bytes": 2.0}]},
@@ -115,7 +115,7 @@ class TestConfig(unittest.TestCase):
     def test_lbs_vt_data_reader_read_compressed(self):
         file_prefix = os.path.join(self.data_dir, "synthetic_lb_data_compressed", "data")
         lr = LoadReader(
-            file_prefix=file_prefix, n_ranks=4, logger=self.logger, file_suffix="json")
+            file_prefix=file_prefix, logger=self.logger, file_suffix="json")
         for rank_id in range(4):
             phase_rank, rank_comm = lr._populate_rank(0, rank_id)
             self.assertEqual(self.rank_comm[rank_id], rank_comm)
@@ -135,7 +135,7 @@ class TestConfig(unittest.TestCase):
     def test_lbs_vt_data_reader_read_file_not_found(self):
         with self.assertRaises(FileNotFoundError) as err:
             LoadReader(
-                file_prefix=f"{self.file_prefix}xd", n_ranks=4,
+                file_prefix=f"{self.file_prefix}xd",
                 logger=self.logger, file_suffix="json")._populate_rank(0, 0)
         self.assertIn(err.exception.args[0], [
             f"File {self.file_prefix}xd.0.json not found", f"File {self.file_prefix}xd.1.json not found",
@@ -146,7 +146,7 @@ class TestConfig(unittest.TestCase):
         file_prefix = os.path.join(self.data_dir, "synthetic_lb_data_wrong_schema", "data")
         with self.assertRaises(SchemaError) as err:
             LoadReader(
-                file_prefix=file_prefix, n_ranks=4,
+                file_prefix=file_prefix,
                 logger=self.logger, file_suffix="json")._populate_rank(0, 0)
         list_of_err_msg = []
         with open(os.path.join(


### PR DESCRIPTION
Fixes #353 

This PR includes 
- n_ranks parameter removed from configuration files and configuration schema at the configuration top level
- n_ranks now determined by the LoadReader if loading data files by checking first data file metadata or default by counting data files
- `n_ranks` parameter added to the `from_samplers` configuration section to replace the previously remove `n_ranks` parameter (because now only used with data sampling)
- improvements in code quality
Still a PR check error on PyLint. This will be resolved later by PR #398 