### PR TITLE
#403: fix n_ranks using data files better detection with regex

### DIFF
--- a/tests/unit/data/synthetic_lb_data/README.md
+++ b/tests/unit/data/synthetic_lb_data/README.md
@@ -1,0 +1,1 @@
+This README.md file enables to validate that the VTDataReader does work correctly if non data files resides in the data directory.

--- a/tests/unit/test_lbs_vt_data_reader.py
+++ b/tests/unit/test_lbs_vt_data_reader.py
@@ -4,7 +4,6 @@ import unittest
 
 from schema import SchemaError
 
-from lbaf import PROJECT_PATH
 from lbaf.IO.lbsVTDataReader import LoadReader
 from lbaf.Model.lbsObject import Object
 from lbaf.Model.lbsObjectCommunicator import ObjectCommunicator
@@ -15,8 +14,9 @@ class TestConfig(unittest.TestCase):
     def setUp(self):
         self.data_dir = os.path.join(os.path.dirname(__file__), "data")
         self.file_prefix = os.path.join(self.data_dir, "synthetic_lb_data", "data")
+        self.file_suffix = "json"
         self.logger = logging.getLogger()
-        self.lr = LoadReader(file_prefix=self.file_prefix, logger=self.logger, file_suffix="json")
+        self.lr = LoadReader(file_prefix=self.file_prefix, logger=self.logger, file_suffix=self.file_suffix)
         self.rank_comm = [
             {
                 5: {"sent": [], "received": [{"from": 0, "bytes": 2.0}]},
@@ -81,7 +81,7 @@ class TestConfig(unittest.TestCase):
 
     def test_lbs_vt_data_reader_initialization(self):
         self.assertEqual(self.lr._LoadReader__file_prefix, self.file_prefix)
-        self.assertEqual(self.lr._LoadReader__file_suffix, "json")
+        self.assertEqual(self.lr._LoadReader__file_suffix, self.file_suffix)
 
     def test_lbs_vt_data_reader_get_rank_file_name_001(self):
         file_name = f"{self.lr._LoadReader__file_prefix}.0.{self.lr._LoadReader__file_suffix}"
@@ -115,7 +115,7 @@ class TestConfig(unittest.TestCase):
     def test_lbs_vt_data_reader_read_compressed(self):
         file_prefix = os.path.join(self.data_dir, "synthetic_lb_data_compressed", "data")
         lr = LoadReader(
-            file_prefix=file_prefix, logger=self.logger, file_suffix="json")
+            file_prefix=file_prefix, logger=self.logger, file_suffix=self.file_suffix)
         for rank_id in range(4):
             phase_rank, rank_comm = lr._populate_rank(0, rank_id)
             self.assertEqual(self.rank_comm[rank_id], rank_comm)
@@ -136,10 +136,10 @@ class TestConfig(unittest.TestCase):
         with self.assertRaises(FileNotFoundError) as err:
             LoadReader(
                 file_prefix=f"{self.file_prefix}xd",
-                logger=self.logger, file_suffix="json")._populate_rank(0, 0)
+                logger=self.logger, file_suffix=self.file_suffix)._populate_rank(0, 0)
         self.assertIn(err.exception.args[0], [
-            f"File {self.file_prefix}xd.0.json not found", f"File {self.file_prefix}xd.1.json not found",
-            f"File {self.file_prefix}xd.2.json not found", f"File {self.file_prefix}xd.3.json not found"
+            f"File {self.file_prefix}xd.0.{self.file_suffix} not found", f"File {self.file_prefix}xd.1.{self.file_suffix} not found",
+            f"File {self.file_prefix}xd.2.{self.file_suffix} not found", f"File {self.file_prefix}xd.3.{self.file_suffix} not found"
         ])
 
     def test_lbs_vt_data_reader_read_wrong_schema(self):
@@ -147,7 +147,7 @@ class TestConfig(unittest.TestCase):
         with self.assertRaises(SchemaError) as err:
             LoadReader(
                 file_prefix=file_prefix,
-                logger=self.logger, file_suffix="json")._populate_rank(0, 0)
+                logger=self.logger, file_suffix=self.file_suffix)._populate_rank(0, 0)
         list_of_err_msg = []
         with open(os.path.join(
             self.data_dir,
@@ -212,6 +212,7 @@ class TestConfig(unittest.TestCase):
             self.assertEqual(prep_comm_rcv_list, gen_comm_rcv_list)
             self.assertEqual(prep_comm_rcv_load_list, gen_comm_rcv_load_list)
             self.assertEqual(prep_comm_rcv_id_list, gen_comm_rcv_id_list)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #403 

The `n_ranks` value detection is now using regex against data file names when it does not exist in meta data.

n_ranks is now using `max(rank_id) + 1` where `rank_id`'s are extracted from the file name (because file are named like : `{file_prefix}.{rank_id}.{file_suffix}`