### PR TITLE
#352: Create baseline/global YAML configuration file

### DIFF
--- a/config/global.yaml
+++ b/config/global.yaml
@@ -1,0 +1,3 @@
+# global parameters uto use in case it is not defined in a configuration file
+
+output_dir: ../output

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -1,3 +1,3 @@
-# global parameters uto use in case it is not defined in a configuration file
+# Global configuration
 
 output_dir: ../output

--- a/src/lbaf/Applications/LBAF_app.py
+++ b/src/lbaf/Applications/LBAF_app.py
@@ -190,11 +190,14 @@ class LBAFApplication:
         data = dest.copy()
         for k in src:
             if not k in data:
+                # if new key
                 data[k] = src[k]
             else:
-                # exists but inner key might be overriden
+                # if key exists in both src and dest
                 if isinstance(src[k], dict) and isinstance(data[k], dict):
-                    data[k] = self.__merge(src[k], data[k])
+                    data[k] = self.__merge(src[k], dest[k])
+                else:
+                    data[k] = src[k]
         return data
 
     def __read_configuration_file(self, path: str):
@@ -223,8 +226,8 @@ class LBAFApplication:
         global_ = self.__read_configuration_file(global_path) if global_path is not None else []
 
         data = {}
-        data = self.__merge(local, data)
         data = self.__merge(global_, data)
+        data = self.__merge(local, data)
 
         # Change logger (with parameters from the configuration data)
         lvl = cast(str, data.get("logging_level", "info"))

--- a/src/lbaf/Applications/LBAF_app.py
+++ b/src/lbaf/Applications/LBAF_app.py
@@ -67,13 +67,11 @@ class InternalParameters:
 
     def validate_configuration(self, config: dict):
         """Configuration file validation."""
-
         ConfigurationValidator(
             config_to_validate=config, logger=self.__logger).main()
 
     def init_parameters(self, config: dict, base_dir: str):
         """Execute when YAML configuration file was found and checked"""
-
         # Get top-level allowed configuration keys
         self.__allowed_config_keys = cast(list, ConfigurationValidator.allowed_keys())
 
@@ -388,18 +386,19 @@ class LBAFApplication:
                                   "working directory or in the project config directory !")
             self.__args.configuration = "conf.yaml"
 
-        # Find configuration file (global and current) absolute path
+        # Find configuration files
         config_file_list = []
+        # Global configuration (optional)
+        try:
+            config_file_list.append(self.__resolve_config_path("global.yaml"))
+        except FileNotFoundError:
+            pass
+        # Local/Specialized configuration (required)
         try:
             config_file_list.append(self.__resolve_config_path(self.__args.configuration))
         except(FileNotFoundError) as err:
             self.__logger.error(err)
             raise SystemExit(-1) from err
-
-        try:
-            config_file_list.append(self.__resolve_config_path("global.yaml"))
-        except FileNotFoundError:
-            pass
 
         # Apply configuration
         cfg = self.__configure(*config_file_list)

--- a/tests/unit/test_lbaf_app.py
+++ b/tests/unit/test_lbaf_app.py
@@ -1,0 +1,77 @@
+import unittest
+
+from lbaf.Applications.LBAF_app import LBAFApplication
+
+class TestLBAFApplication(unittest.TestCase):
+    """Tests for LBAFApplication"""
+
+    def setUp(self):
+        pass
+
+    def _global_conf(self) -> dict:
+        """Sample global configuration subset"""
+        return {
+            "algorithm": {
+                "name": "BruteForce",
+                "parameters": {
+                    "transfer_strategy": "Recursive",
+                }
+            },
+            "output_dir": "../output",
+            "write_JSON": {
+                "compressed": False,
+                "suffix": "json",
+                "communications": True,
+                "offline_LB_compatible": False
+            }
+        }
+
+    def _local_conf(self) -> dict:
+        """Sample local configuration subset"""
+        return {
+            "from_data": {
+                "data_stem": "../data/synthetic_lb_data/data",
+                "phase_ids": [0]
+            },
+            "check_schema": False,
+            "algorithm": {
+                "name": "InformAndTransfer",
+                "parameters": {
+                    "fanout": 3
+                }
+            }
+        }
+
+    def test_configuration_merge(self):
+        """Test that 2 dictionaries generates a single dictionay as expected.
+
+        The following are tested:
+        - Keys defined only in global configuration
+        - Keys defined only in local configuration
+        - Keys that must be overriden by the local configuration
+        """
+
+        app = LBAFApplication()
+        data = {}
+        # Inject some global configuration
+        data = app._LBAFApplication__merge(self._global_conf(), data)
+        global_conf = self._global_conf()
+        local_conf = self._local_conf()
+        # Test merge results in a copy of the global configuration
+        self.assertDictEqual(data, global_conf)
+
+        # Inject some local configuration
+        data = app._LBAFApplication__merge(local_conf, data)
+        # Keys defined only in global config must still be there
+        self.assertIsNotNone(data.get("write_JSON", None))
+        self.assertDictEqual(data.get("write_JSON"), global_conf.get("write_JSON")) # dict should also be the same
+        self.assertEqual(data.get("algorithm", {}).get("parameters", {}).get("transfer_strategy"),"Recursive")
+        self.assertEqual(data.get("output_dir", {}),"../output")
+        # Keys defined only in local config must also be there
+        self.assertIsNotNone(data.get("from_data", None))
+        # Keys that must be overriden by the local configuration
+        self.assertEqual(data.get("algorithm", {}).get("name"), "InformAndTransfer")
+        self.assertEqual(data.get("algorithm", {}).get("parameters", {}).get("fanout"), 3)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #352 

- Adds support of global configuration file if present at <project_path>/config/global.yaml or <cwd>/global.yaml 
- Add basic global.yaml file with output_dir default value of "../output". 

I think it will be important later to define what goes in global.yaml and what should be removed for some configurations files on the repo (like the "output_dir" key)
