### PR TITLE
#418: Failure of test_vt_data_extractor_014 in CI

### DIFF
--- a/src/lbaf/Execution/lbsCentralizedPrefixOptimizerAlgorithm.py
+++ b/src/lbaf/Execution/lbsCentralizedPrefixOptimizerAlgorithm.py
@@ -1,11 +1,8 @@
-import sys
-import math
 import heapq
 from logging import Logger
 
 from .lbsAlgorithmBase import AlgorithmBase
 from ..IO.lbsStatistics import print_function_statistics
-from ..Utils.exception_handler import exc_handler
 
 
 class CentralizedPrefixOptimizerAlgorithm(AlgorithmBase):
@@ -22,6 +19,8 @@ class CentralizedPrefixOptimizerAlgorithm(AlgorithmBase):
             work_model, parameters, lgr, qoi_name, obj_qoi)
 
         self._do_second_stage = parameters.get("do_second_stage", False)
+        self._phase = None
+        self._max_shared_ids = None
 
     def execute(self, p_id: int, phases: list, distributions: dict, statistics: dict, _):
         """ Execute centralized prefix memory-constrained optimizer"""
@@ -37,7 +36,7 @@ class CentralizedPrefixOptimizerAlgorithm(AlgorithmBase):
         self._update_distributions_and_statistics(distributions, statistics)
 
         # Prepare input data for rank order enumerator
-        self._logger.info(f"Starting optimizer")
+        self._logger.info("Starting optimizer")
         phase_ranks = self._phase.get_ranks()
 
         # Initialize max shared ID
@@ -52,7 +51,7 @@ class CentralizedPrefixOptimizerAlgorithm(AlgorithmBase):
 
         # Add the ranks to the list
         for rank in phase_ranks:
-            rank_max_heap.append(rank);
+            rank_max_heap.append(rank)
 
         # Iterate until number of assignments reached
         made_no_assignments = 0
@@ -185,7 +184,6 @@ class CentralizedPrefixOptimizerAlgorithm(AlgorithmBase):
         for o in objs[sid]:
             if len(rank_min_heap) == 0:
                 self._logger.error("Reached condition where no ranks could take the element!")
-                sys.excepthook = exc_handler
                 raise SystemExit(1)
 
             # Pick the rank that is most underloaded (greedy)

--- a/src/lbaf/Execution/lbsCentralizedPrefixOptimizerAlgorithm.py
+++ b/src/lbaf/Execution/lbsCentralizedPrefixOptimizerAlgorithm.py
@@ -163,7 +163,6 @@ class CentralizedPrefixOptimizerAlgorithm(AlgorithmBase):
         """Try to find a rank to offload a bin (load grouping that shares a
         common memory ID)"""
 
-        
         # Min-heap of ranks
         rank_min_heap = []
 

--- a/tests/unit/test_vt_data_extractor.py
+++ b/tests/unit/test_vt_data_extractor.py
@@ -265,9 +265,14 @@ class TestVTDataExtractor(unittest.TestCase):
                                 file_prefix="data", file_suffix="json", compressed=False, schema_type="LBDatafile",
                                 check_schema=False, logger=self.logger).main()
             # Check logger message
-            self.assertEqual(cm.output, [
-                "ERROR:root:Values in filenames can not be converted to `int`.\nPhases are not sorted.\n"
-                "ERROR: invalid literal for int() with base 10: 'other'"])
+            # 2 files have wrong names but since it is loaded parallel we can expect an error for one or the other file
+            invalid_values = ['sm', 'other']
+            self.assertTrue(
+                any(cm.output == [
+                    "ERROR:root:Values in filenames can not be converted to `int`.\nPhases are not sorted.\n"
+                    f"ERROR: invalid literal for int() with base 10: '{x}'"]
+                    for x in invalid_values)
+            )
 
     def test_vt_data_extractor_015(self):
         phases = [0, 1]
@@ -314,10 +319,11 @@ class TestVTDataExtractor(unittest.TestCase):
         with self.assertLogs(self.logger, level="ERROR") as cm:
             with self.assertRaises(SystemExit):
                 VTDataExtractor(input_data_dir=input_dir, output_data_dir=output_data_dir, phases_to_extract=phases,
-                                    file_prefix="data", file_suffix="json", compressed=False, schema_type="LBDatafile",
-                                    check_schema=False, logger=self.logger).main()
+                                file_prefix="data", file_suffix="json", compressed=False, schema_type="LBDatafile",
+                                check_schema=False, logger=self.logger).main()
             # Check logger message
             self.assertEqual(cm.output, ["ERROR:root:Input data directory not found."])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #418 

The test related to the vt_data_extractor was in fact failing due to a missing assertion possible value.
Now it works correctly.
Fix also some pylint warnings