### PR TITLE
#376: Enable multiple versions of lbaf to run in the same python environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,7 @@ __pycache__
 /build
 /dist
 /m.css
-/venv
-/venv39
+/venv*
 output
 /src/Applications/Include
 /src/Applications/Lib

--- a/README.md
+++ b/README.md
@@ -28,11 +28,24 @@ Make sure you have all required Python packages installed with:
 pip install -r requirements.txt
 ```
 
+By default requirements installs also the lbaf package in editable mode as you can see by running `pip list`
+
 Requirements are divided into `LBAF dependencies` and `LBAF testing`.
 
 `LBAF dependencies` are needed in order to LBAF to work.
 
 `LBAF testing` are needed for testing purposes.
+
+## Support of multiple versions under the same python environment (at the same time)
+
+There is a particular case where you may need to manage multiple local lbaf installs on your machine at the same time.
+Since pip only supports 1 package version install, you will have to remove the pip dependency to lbaf itself by running:
+```shell
+pip uninstall lbaf
+```
+Then lbaf module will be loaded directly from the project directory.
+
+Another possibility is to create a virtual environment for each of you LBAF versions to be able to get the advantages of a keeping lbaf as a package (advantages like being able to access package commands)
 
 ## Configuration file
 
@@ -60,13 +73,12 @@ tox
 
 ### LBAF
 
-In order to run LBAF:
-
+If the lbaf package is installed you can run LBAF using the following command:
 ```shell
 lbaf -c <config-file-name>
 ```
 
-or
+Or run LBAF from source:
 
 ```shell
 cd <project-path>
@@ -83,11 +95,11 @@ JSON data files Validator validates VT data files against defined schema. It is 
 
 ## Download into LBAF
 
-A command can be used to only download the data files validator without running it
+To run using the lbaf package:
 ```shell
 lbaf-vt-data-files-validator-loader
 ```
-or
+To run from source:
 ```shell
 cd <project-path>
 python src/lbaf/Utils/lbsJSONDataFilesValidatorLoader.py
@@ -97,11 +109,11 @@ The script is then saved to `<project-path>/src/lbaf/imported/JSON_data_files_va
 
 ## Download and Run from LBAF
 
-it can be run with
+To run using the lbaf package:
 ```shell
 lbaf-vt-data-files-validator
 ```
-or
+To run from source:
 ```shell
 cd <project-path>
 python src/lbaf/imported/JSON_data_files_validator.py
@@ -136,11 +148,12 @@ lbaf-vt-data-files-validator --dir_path=../../data/nolb-8color-16nodes-data --fi
 ### VT data Extractor
 
 VT data Extractor extracts phases from VT stats files.
-VT data Extractor can be run using the following command:
+
+To run using the lbaf package:
 ```shell
 lbaf-vt-data-extractor
 ```
-or
+To run from source:
 ```shell
 cd <project-path>
 python src/lbaf/Utils/lbsVTDataExtractor.py

--- a/README.md
+++ b/README.md
@@ -23,29 +23,44 @@ The recommended version is Python 3.8. This is because configuration key `save_m
 
 Please mind your platform as well as proper 32 or 64 bit version.
 
-Make sure you have all required Python packages installed with:
+### Setup virtual environment(s) *(recommended in development)*
+
+It is recommended in development mode to create and use virtual environments.
+
+To create a virtual environment for lbaf supported Python versions and activate Python3.8 the first (for example):
 ```shell
+python3.8 -m venv venv
+python3.9 -m venv venv39
+. venv/bin/activate
+```
+Please note that virtual environment names should be prefixed by 'venv' as a convention.
+Once an environment has been created and is active you can install the lbaf package using `pip install -e .` or just the requirements using `pip install -r requirements.txt`.
+
+### Install **lbaf** package
+*recommended in development except if multiple versions must run in the same environment*
+
+If you don't need to install several versions of LBAF you can install LBAF as a package from the project directory and in editable mode.
+To do so mode please run the following command: `pip install -e .` from the project directory. It will also install automatically the required dependencies.
+*Note: pip package manager does not support to host different versions of the same package in a single python environment*). 
+*Note: Although not required, it's common to locally install the project in "editable" or "develop" mode while you're working on it. This allows your project to be both installed and editable in project form.*
+
+### Install dependencies
+
+If LBAF has not been installed as a package (for example because you have multiple versions of LBAF on your machine) you will run LBAF differently and you have to install the dependencies by running the following command:
+```shell
+cd <project-path>
 pip install -r requirements.txt
 ```
 
-By default requirements installs also the lbaf package in editable mode as you can see by running `pip list`
+In general, it is often recommended during development to use python virtual environments and it is possible to have also environments dedicated to some development branches 
+(You can for example checkout a branch and run in a dedicated environment. For example a Python3.8 environment for the branch 125 could be named "venv38-branch-125" and then you could install lbaf as a package in editable mode inside this environment only)
+
 
 Requirements are divided into `LBAF dependencies` and `LBAF testing`.
 
 `LBAF dependencies` are needed in order to LBAF to work.
 
 `LBAF testing` are needed for testing purposes.
-
-## Support of multiple versions under the same python environment (at the same time)
-
-There is a particular case where you may need to manage multiple local lbaf installs on your machine at the same time.
-Since pip only supports 1 package version install, you will have to remove the pip dependency to lbaf itself by running:
-```shell
-pip uninstall lbaf
-```
-Then lbaf module will be loaded directly from the project directory.
-
-Another possibility is to create a virtual environment for each of you LBAF versions to be able to get the advantages of a keeping lbaf as a package (advantages like being able to access package commands)
 
 ## Configuration file
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Please mind your platform as well as proper 32 or 64 bit version.
 ### Setup virtual environment(s) *(recommended in development)*
 
 It is recommended in development mode to create and use virtual environments.
+To be able to use virtual environments please install the virtualenv package using the command `pip install virtualenv`
 
 To create a virtual environment for lbaf supported Python versions and activate Python3.8 the first (for example):
 ```shell
@@ -41,7 +42,7 @@ Once an environment has been created and is active you can install the lbaf pack
 
 If you don't need to install several versions of LBAF you can install LBAF as a package from the project directory and in editable mode.
 To do so mode please run the following command: `pip install -e .` from the project directory. It will also install automatically the required dependencies.
-*Note: pip package manager does not support to host different versions of the same package in a single python environment*). 
+*Note: pip package manager does not support to host different versions of the same package in a single python environment*).
 *Note: Although not required, it's common to locally install the project in "editable" or "develop" mode while you're working on it. This allows your project to be both installed and editable in project form.*
 
 ### Install dependencies
@@ -52,7 +53,7 @@ cd <project-path>
 pip install -r requirements.txt
 ```
 
-In general, it is often recommended during development to use python virtual environments and it is possible to have also environments dedicated to some development branches 
+In general, it is often recommended during development to use python virtual environments and it is possible to have also environments dedicated to some development branches
 (You can for example checkout a branch and run in a dedicated environment. For example a Python3.8 environment for the branch 125 could be named "venv38-branch-125" and then you could install lbaf as a package in editable mode inside this environment only)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,9 +24,3 @@ docutils==0.19
 
 # LBAF building package
 build==0.7.0
-
-# installs lbaf in editable mode
-# Please note that it is not compatible for testing multiple versions on the same machine.
-# In that particular case please remove lbaf package using the command `pip uninstall lbaf`
-# so it will be loaded relative to the current project directory.
--e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,5 +25,8 @@ docutils==0.19
 # LBAF building package
 build==0.7.0
 
-# project packages (editable mode)
+# installs lbaf in editable mode
+# Please note that it is not compatible for testing multiple versions on the same machine.
+# In that particular case please remove lbaf package using the command `pip uninstall lbaf`
+# so it will be loaded relative to the current project directory.
 -e .

--- a/src/lbaf/Applications/LBAF_app.py
+++ b/src/lbaf/Applications/LBAF_app.py
@@ -9,7 +9,7 @@ import yaml
 # pylint:disable=C0413:wrong-import-position
 # Use lbaf module from source if lbaf package is not installed
 if importlib.util.find_spec('lbaf') is None:
-    sys.path.insert(0, (os.path.dirname(__file__) + "/../"))
+    sys.path.insert(0, (os.path.dirname(__file__) + "/../../"))
 import lbaf.IO.lbsStatistics as lbstats
 from lbaf import PROJECT_PATH, __version__
 from lbaf.Execution.lbsRuntime import Runtime

--- a/src/lbaf/Applications/LBAF_app.py
+++ b/src/lbaf/Applications/LBAF_app.py
@@ -3,9 +3,13 @@ import math
 import os
 import sys
 from typing import Any, Dict, Optional, cast
-
+import importlib
 import yaml
 
+# pylint:disable=C0413:wrong-import-position
+# Use lbaf module from source if lbaf package is not installed
+if importlib.util.find_spec('lbaf') is None:
+    sys.path.insert(0, (os.path.dirname(__file__) + "/../"))
 import lbaf.IO.lbsStatistics as lbstats
 from lbaf import PROJECT_PATH, __version__
 from lbaf.Execution.lbsRuntime import Runtime
@@ -19,7 +23,7 @@ from lbaf.Utils.lbsJSONDataFilesValidatorLoader import \
     JSONDataFilesValidatorLoader
 from lbaf.Utils.lbsLogging import Logger, get_logger
 from lbaf.Utils.lbsPath import abspath
-
+# pylint:enable=C0413:wrong-import-position
 
 class InternalParameters:
     """Represent the parameters used internally by a a LBAF Application"""

--- a/src/lbaf/Applications/MoveCountsViewer.py
+++ b/src/lbaf/Applications/MoveCountsViewer.py
@@ -1,13 +1,17 @@
 import os
 import sys
 import csv
-
+import importlib
 import vtk
 
+# pylint:disable=C0413:wrong-import-position
+# Use lbaf module from source if lbaf package is not installed
+if importlib.util.find_spec('lbaf') is None:
+    sys.path.insert(0, (os.path.dirname(__file__) + "/../../"))
 from lbaf import PROJECT_PATH
 from lbaf.Utils.lbsLogging import get_logger, Logger
 from lbaf.Utils.lbsArgumentParser import PromptArgumentParser
-
+# pylint:enable=C0413:wrong-import-position
 
 class MoveCountsViewerParameters:
     """A class to describe MoveCountsViewer parameters."""

--- a/src/lbaf/Utils/lbsCsv2JsonDataConverter.py
+++ b/src/lbaf/Utils/lbsCsv2JsonDataConverter.py
@@ -1,13 +1,20 @@
 import csv
+import importlib
 import json
 import os
+import sys
 from collections import Counter
 
 import brotli
 
+# pylint:disable=C0413:wrong-import-position
+# Use lbaf module from source if lbaf package is not installed
+if importlib.util.find_spec('lbaf') is None:
+    sys.path.insert(0, (os.path.dirname(__file__) + "/../../"))
 from lbaf import PROJECT_PATH
 from lbaf.Utils.lbsArgumentParser import PromptArgumentParser
 from lbaf.Utils.lbsLogging import get_logger
+# pylint:disable=C0413:wrong-import-position
 
 
 class Csv2JsonConverter:

--- a/src/lbaf/Utils/lbsDataStatFilesUpdater.py
+++ b/src/lbaf/Utils/lbsDataStatFilesUpdater.py
@@ -1,12 +1,18 @@
 """src/lbaf/Utils/lbsDataStatFilesUpdater.py"""
+import importlib
 import json
 import os
+import sys
 from collections import Counter
 
 import brotli
-
+# pylint:disable=C0413:wrong-import-position
+# Use lbaf module from source if lbaf package is not installed
+if importlib.util.find_spec('lbaf') is None:
+    sys.path.insert(0, (os.path.dirname(__file__) + "/../../"))
 from lbaf.Utils.lbsArgumentParser import PromptArgumentParser
 from lbaf.Utils.lbsLogging import get_logger
+# pylint:disable=C0413:wrong-import-position
 
 
 class DataStatFilesUpdater:

--- a/src/lbaf/Utils/lbsJSONDataFilesValidatorLoader.py
+++ b/src/lbaf/Utils/lbsJSONDataFilesValidatorLoader.py
@@ -1,10 +1,17 @@
+import importlib
 import os
+import sys
 from typing import Optional
 
+# pylint:disable=C0413:wrong-import-position
+# Use lbaf module from source if lbaf package is not installed
+if importlib.util.find_spec('lbaf') is None:
+    sys.path.insert(0, (os.path.dirname(__file__) + "/../../"))
 from lbaf import PROJECT_PATH, __version__
 from lbaf.Utils.lbsArgumentParser import PromptArgumentParser
 from lbaf.Utils.lbsLogging import Logger, get_logger
 from lbaf.Utils.lbsWeb import download
+# pylint:disable=C0413:wrong-import-position
 
 IMPORT_DIR = os.path.join(PROJECT_PATH, "src", "lbaf", "imported")
 TARGET_SCRIPT_NAME = "JSON_data_files_validator.py"

--- a/src/lbaf/Utils/lbsVTDataExtractor.py
+++ b/src/lbaf/Utils/lbsVTDataExtractor.py
@@ -1,14 +1,21 @@
 import argparse
+import importlib
 import json
 import os
+import sys
 import time
 from multiprocessing import get_context
 from multiprocessing.pool import Pool
 from typing import Optional
 
+# pylint:disable=C0413:wrong-import-position
+# Use lbaf module from source if lbaf package is not installed
+if importlib.util.find_spec('lbaf') is None:
+    sys.path.insert(0, (os.path.dirname(__file__) + "/../../"))
 from lbaf import PROJECT_PATH
 from lbaf.Utils.lbsArgumentParser import PromptArgumentParser
 from lbaf.Utils.lbsLogging import get_logger, Logger
+# pylint:disable=C0413:wrong-import-position
 
 try:
     import brotli

--- a/src/lbaf/__init__.py
+++ b/src/lbaf/__init__.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import importlib
 
 
 __version__ = "0.1.0rc1"
@@ -11,6 +12,9 @@ PROJECT_PATH = os.path.abspath(os.path.dirname(os.path.realpath(__file__)) + "/.
 """project path (with data, config, tests)"""
 
 # pylint:disable=C0413:wrong-import-position
+# Use lbaf module from source if lbaf package is not installed
+if importlib.util.find_spec('lbaf') is None:
+    sys.path.insert(0, (os.path.dirname(__file__) + "/../"))
 from lbaf.Applications.LBAF_app import LBAFApplication
 from lbaf.Utils.lbsVTDataExtractor import VTDataExtractorRunner
 from lbaf.Utils.lbsJSONDataFilesValidatorLoader import JSONDataFilesValidatorLoader

--- a/src/lbaf/__main__.py
+++ b/src/lbaf/__main__.py
@@ -1,3 +1,13 @@
 """LBAF module"""
-from .Applications.LBAF_app import LBAFApplication
+
+import os
+import sys
+import importlib
+
+# Use lbaf module from source if lbaf package is not installed
+if importlib.util.find_spec('lbaf') is None:
+    sys.path.insert(0, (os.path.dirname(__file__) + "/../"))
+
+# Default run a LBAFApplication instance
+from lbaf.Applications.LBAF_app import LBAFApplication  # pylint:disable=C0413:wrong-import-position)
 LBAFApplication().run()

--- a/tests/acceptance/test_acceptance.py
+++ b/tests/acceptance/test_acceptance.py
@@ -17,7 +17,7 @@ class TestAcceptance(unittest.TestCase):
         """Runs acceptance tests"""
         # run LBAF
         config_file = os.path.join(os.path.dirname(__file__), "config", "synthetic-acceptance.yaml")
-        subprocess.run(["lbaf", "-c", config_file], check=True)
+        subprocess.run(["python", "src/lbaf", "-c", config_file], check=True)
 
         imbalance_file = os.path.join(os.path.dirname(__file__), "output", "imbalance.txt")
 

--- a/tests/acceptance/test_stepper.py
+++ b/tests/acceptance/test_stepper.py
@@ -16,7 +16,7 @@ class TestStepper(unittest.TestCase):
         """Runs stepper tests"""
         # run LBAF
         config_file = os.path.join(os.path.dirname(__file__), "config", "stepper.yaml")
-        subprocess.run(["lbaf", "-c", config_file], check=True)
+        subprocess.run(["python", "src/lbaf", "-c", config_file], check=True)
         log_file = os.path.join(os.path.dirname(__file__), "output", "log.txt")
 
         # check log file exists

--- a/tests/test_lbs_inform_and_transfer_algorithm.py
+++ b/tests/test_lbs_inform_and_transfer_algorithm.py
@@ -2,12 +2,12 @@ import logging
 import random
 import unittest
 from unittest.mock import patch
-
-from lbaf.Model.lbsMessage import Message
-from lbaf.Model.lbsObject import Object
-from lbaf.Model.lbsRank import Rank
-from lbaf.Execution.lbsInformAndTransferAlgorithm import InformAndTransferAlgorithm
-from lbaf.Model.lbsWorkModelBase import WorkModelBase
+import tests
+from src.lbaf.Model.lbsMessage import Message
+from src.lbaf.Model.lbsObject import Object
+from src.lbaf.Model.lbsRank import Rank
+from src.lbaf.Execution.lbsInformAndTransferAlgorithm import InformAndTransferAlgorithm
+from src.lbaf.Model.lbsWorkModelBase import WorkModelBase
 
 class TestConfig(unittest.TestCase):
     def setUp(self):

--- a/tests/test_lbs_inform_and_transfer_algorithm.py
+++ b/tests/test_lbs_inform_and_transfer_algorithm.py
@@ -2,7 +2,7 @@ import logging
 import random
 import unittest
 from unittest.mock import patch
-import tests
+
 from src.lbaf.Model.lbsMessage import Message
 from src.lbaf.Model.lbsObject import Object
 from src.lbaf.Model.lbsRank import Rank

--- a/tests/unit/test_JSON_data_files_validator.py
+++ b/tests/unit/test_JSON_data_files_validator.py
@@ -7,11 +7,11 @@ from unittest.mock import Mock
 
 from schema import SchemaError
 
-from lbaf.Utils.lbsJSONDataFilesValidatorLoader import JSONDataFilesValidatorLoader
+from src.lbaf.Utils.lbsJSONDataFilesValidatorLoader import JSONDataFilesValidatorLoader
 loader = JSONDataFilesValidatorLoader()
 loader.run({ "overwrite": True })
 
-from lbaf.imported.JSON_data_files_validator import JSONDataFilesValidator
+from src.lbaf.imported.JSON_data_files_validator import JSONDataFilesValidator
 
 
 class TestJSONDataFilesValidator(unittest.TestCase):

--- a/tests/unit/test_configuration_validator.py
+++ b/tests/unit/test_configuration_validator.py
@@ -4,9 +4,9 @@ import unittest
 from schema import SchemaError, SchemaMissingKeyError, SchemaOnlyOneAllowedError
 import yaml
 
-from lbaf.Utils.lbsPath import abspath
-from lbaf.IO.lbsConfigurationValidator import ConfigurationValidator
-from lbaf.Utils.lbsLogging import get_logger
+from src.lbaf.Utils.lbsPath import abspath
+from src.lbaf.IO.lbsConfigurationValidator import ConfigurationValidator
+from src.lbaf.Utils.lbsLogging import get_logger
 
 
 class TestConfig(unittest.TestCase):

--- a/tests/unit/test_lbaf_app.py
+++ b/tests/unit/test_lbaf_app.py
@@ -1,6 +1,6 @@
 import unittest
 
-from lbaf.Applications.LBAF_app import LBAFApplication
+from src.lbaf.Applications.LBAF_app import LBAFApplication
 
 class TestLBAFApplication(unittest.TestCase):
     """Tests for LBAFApplication"""

--- a/tests/unit/test_lbs_message.py
+++ b/tests/unit/test_lbs_message.py
@@ -1,6 +1,7 @@
 import unittest
 
-from lbaf.Model.lbsMessage import Message
+from src.lbaf.Model.lbsMessage import Message
+
 
 class TestConfig(unittest.TestCase):
     def setUp(self):

--- a/tests/unit/test_lbs_object.py
+++ b/tests/unit/test_lbs_object.py
@@ -1,8 +1,8 @@
 import logging
 import unittest
 
-from lbaf.Model.lbsObject import Object
-from lbaf.Model.lbsObjectCommunicator import ObjectCommunicator
+from src.lbaf.Model.lbsObject import Object
+from src.lbaf.Model.lbsObjectCommunicator import ObjectCommunicator
 
 
 class TestConfig(unittest.TestCase):

--- a/tests/unit/test_lbs_object_communicator.py
+++ b/tests/unit/test_lbs_object_communicator.py
@@ -1,8 +1,8 @@
 import logging
 import unittest
 
-from lbaf.Model.lbsObject import Object
-from lbaf.Model.lbsObjectCommunicator import ObjectCommunicator
+from src.lbaf.Model.lbsObject import Object
+from src.lbaf.Model.lbsObjectCommunicator import ObjectCommunicator
 
 
 class TestConfig(unittest.TestCase):

--- a/tests/unit/test_lbs_phase.py
+++ b/tests/unit/test_lbs_phase.py
@@ -3,9 +3,9 @@ import os
 import logging
 import unittest
 
-from lbaf import PROJECT_PATH
-from lbaf.IO.lbsVTDataReader import LoadReader
-from lbaf.Model.lbsPhase import Phase
+from src.lbaf import PROJECT_PATH
+from src.lbaf.IO.lbsVTDataReader import LoadReader
+from src.lbaf.Model.lbsPhase import Phase
 
 
 class TestConfig(unittest.TestCase):

--- a/tests/unit/test_lbs_rank.py
+++ b/tests/unit/test_lbs_rank.py
@@ -3,10 +3,10 @@ import random
 import unittest
 from unittest.mock import patch
 
-from lbaf.Model.lbsMessage import Message
-from lbaf.Model.lbsObject import Object
-from lbaf.Model.lbsObjectCommunicator import ObjectCommunicator
-from lbaf.Model.lbsRank import Rank
+from src.lbaf.Model.lbsMessage import Message
+from src.lbaf.Model.lbsObject import Object
+from src.lbaf.Model.lbsObjectCommunicator import ObjectCommunicator
+from src.lbaf.Model.lbsRank import Rank
 
 
 class TestConfig(unittest.TestCase):

--- a/tests/unit/test_lbs_statistics.py
+++ b/tests/unit/test_lbs_statistics.py
@@ -7,7 +7,7 @@ from scipy import stats
 import unittest
 
 import lbaf.IO.lbsStatistics as lbsStatistics
-from lbaf.IO.lbsStatistics import Statistics
+from src.lbaf.IO.lbsStatistics import Statistics
 
 
 class TestConfig(unittest.TestCase):

--- a/tests/unit/test_lbs_vt_data_reader.py
+++ b/tests/unit/test_lbs_vt_data_reader.py
@@ -4,10 +4,10 @@ import unittest
 
 from schema import SchemaError
 
-from lbaf.IO.lbsVTDataReader import LoadReader
-from lbaf.Model.lbsObject import Object
-from lbaf.Model.lbsObjectCommunicator import ObjectCommunicator
-from lbaf.Model.lbsRank import Rank
+from src.lbaf.IO.lbsVTDataReader import LoadReader
+from src.lbaf.Model.lbsObject import Object
+from src.lbaf.Model.lbsObjectCommunicator import ObjectCommunicator
+from src.lbaf.Model.lbsRank import Rank
 
 
 class TestConfig(unittest.TestCase):

--- a/tests/unit/test_lbs_work_model_base.py
+++ b/tests/unit/test_lbs_work_model_base.py
@@ -2,8 +2,8 @@ import os
 import logging
 import unittest
 
-from lbaf import PROJECT_PATH
-from lbaf.Model.lbsWorkModelBase import WorkModelBase
+from src.lbaf import PROJECT_PATH
+from src.lbaf.Model.lbsWorkModelBase import WorkModelBase
 
 
 class TestConfig(unittest.TestCase):

--- a/tests/unit/test_schema_validator.py
+++ b/tests/unit/test_schema_validator.py
@@ -4,10 +4,10 @@ import unittest
 
 import brotli
 
-from lbaf.Utils.lbsJSONDataFilesValidatorLoader import JSONDataFilesValidatorLoader
+from src.lbaf.Utils.lbsJSONDataFilesValidatorLoader import JSONDataFilesValidatorLoader
 
 JSONDataFilesValidatorLoader().run(overwrite=True)
-from lbaf.imported.JSON_data_files_validator import SchemaValidator  # pylint:disable=C0413:wrong-import-position
+from src.lbaf.imported.JSON_data_files_validator import SchemaValidator  # pylint:disable=C0413:wrong-import-position
 
 
 class TestConfig(unittest.TestCase):

--- a/tests/unit/test_vt_data_extractor.py
+++ b/tests/unit/test_vt_data_extractor.py
@@ -11,8 +11,8 @@ import sys
 
 import brotli
 
-from lbaf.Utils.lbsVTDataExtractor import VTDataExtractor
-from lbaf.Utils.lbsLogging import get_logger
+from src.lbaf.Utils.lbsVTDataExtractor import VTDataExtractor
+from src.lbaf.Utils.lbsLogging import get_logger
 
 
 class TestVTDataExtractor(unittest.TestCase):

--- a/tests/unit/test_vt_writer.py
+++ b/tests/unit/test_vt_writer.py
@@ -10,11 +10,11 @@ import brotli
 import yaml
 from schema import Optional
 
-from lbaf.Utils.lbsJSONDataFilesValidatorLoader import JSONDataFilesValidatorLoader
-from lbaf.Utils.lbsPath import abspath
+from src.lbaf.Utils.lbsJSONDataFilesValidatorLoader import JSONDataFilesValidatorLoader
+from src.lbaf.Utils.lbsPath import abspath
 
 JSONDataFilesValidatorLoader().run(overwrite=True)
-from lbaf.imported.JSON_data_files_validator import SchemaValidator  # pylint:disable=C0413:wrong-import-position
+from src.lbaf.imported.JSON_data_files_validator import SchemaValidator  # pylint:disable=C0413:wrong-import-position
 
 
 class TestVTDataWriter(unittest.TestCase):
@@ -114,7 +114,7 @@ class TestVTDataWriter(unittest.TestCase):
 
         # run LBAF
         config_file = os.path.join(os.path.dirname(__file__), "config", "conf_vt_writer_stepper_test.yml")
-        proc = subprocess.run(["lbaf", "-c", config_file], check=True)
+        proc = subprocess.run(["python", "src/lbaf", "-c", config_file], check=True)
         self.assertEqual(0, proc.returncode)
 
         # LBAF config useful information


### PR DESCRIPTION
Fixes #376 

This PR 
- Restore the way to run LBAF not as a package. When package is not installed then the lbaf module will be resolved relative to the current project directory automatically.
- For users who want to run development mode using lbaf as a package they will have to run `pip install -e .` since it has been removed from requirements.txt
- README.md file has also been re-worked to explain how to use lbaf as a package & adds information about using virtual environments
- Tests are again run against the lbaf source directory (no more the package installation because it may not be installed as a package now)

