### PR TITLE
#426: Number of input files detected incorrectly

### DIFF
--- a/src/lbaf/Applications/LBAF_app.py
+++ b/src/lbaf/Applications/LBAF_app.py
@@ -95,6 +95,7 @@ class InternalParameters:
                 self.phase_ids = list(range(range_list[0], range_list[1] + 1))
             else:
                 self.phase_ids = from_data.get("phase_ids")
+            self.expected_ranks = from_data.get("expected_ranks")
 
         # Parse sampling parameters if present
         from_samplers = config.get("from_samplers")
@@ -441,7 +442,8 @@ class LBAFApplication:
                 file_prefix=self.__parameters.data_stem,
                 logger=self.__logger,
                 file_suffix=file_suffix if file_suffix is not None else "json",
-                check_schema=check_schema)
+                check_schema=check_schema,
+                expected_ranks=self.__parameters.expected_ranks)
             # retrieve n_ranks
             n_ranks = reader.n_ranks
 

--- a/src/lbaf/IO/lbsConfigurationValidator.py
+++ b/src/lbaf/IO/lbsConfigurationValidator.py
@@ -94,13 +94,17 @@ class ConfigurationValidator:
                 Optional("communications"): bool,
                 Optional("offline_LB_compatible"): bool},
         })
-        self.__from_data = Schema(
-            {"data_stem": str,
-             "phase_ids": Or(
-                 And(list, lambda x: all([isinstance(y, int) for y in x]),
-                     error="Should be of type 'list' of 'int' types"),
-                 Regex(r"^[0-9]+-[0-9]+$", error="Should be of type 'str' like '0-100'"))
-             })
+        self.__from_data = Schema({
+            "data_stem": str,
+            "phase_ids": Or(
+                And(list, lambda x: all([isinstance(y, int) for y in x]),
+                    error="Should be of type 'list' of 'int' types"),
+                Regex(r"^[0-9]+-[0-9]+$", error="Should be of type 'str' like '0-100'")),
+            Optional("expected_ranks"): And(
+                int,
+                lambda x: x > 0,
+                error="Should be of type 'int' and > 0")
+            })
         self.__from_samplers = Schema({
             "n_ranks": And(
                 int,


### PR DESCRIPTION
Fixes #426 

This PR includes:
- Fix `n_ranks `value detection by using only from the data file names (no more use `num_nodes` from data files as `n_ranks`)
- Add new optional `expected_ranks` configuration key (int value) to `from_data` configuration node. If it is set and `n_ranks` is different from `expected_ranks` a warning message is displayed to the user.