### PR TITLE
#475: Investigate failing PyPi package (v1.0.1)

### DIFF
--- a/src/lbaf/Execution/lbsAlgorithmBase.py
+++ b/src/lbaf/Execution/lbsAlgorithmBase.py
@@ -148,9 +148,11 @@ class AlgorithmBase:
                 statistics.setdefault(k, []).append(getattr(stats, f"get_{v}")())
 
     def __print_QOI(self,rank_or_obj):
-        """Print list of implemented QOI based on the '-verbosity' command line argument."""
+        """Print list of implemented QOI when invalid QOI is given."""
         # Initialize file paths
-        TARGET_DIR = os.path.join(PROJECT_PATH, "src", "lbaf", "Model")
+        CURRENT_PATH = os.path.abspath(__file__)
+        TARGET_DIR = os.path.join(
+            os.path.dirname(os.path.dirname(CURRENT_PATH)), "Model")
         RANK_SCRIPT_NAME = "lbsRank.py"
         OBJECT_SCRIPT_NAME = "lbsObject.py"
 

--- a/src/lbaf/Utils/lbsJSONDataFilesValidatorLoader.py
+++ b/src/lbaf/Utils/lbsJSONDataFilesValidatorLoader.py
@@ -13,7 +13,10 @@ from lbaf.Utils.lbsLogging import Logger, get_logger
 from lbaf.Utils.lbsWeb import download
 # pylint:disable=C0413:wrong-import-position
 
-IMPORT_DIR = os.path.join(PROJECT_PATH, "src", "lbaf", "imported")
+CURRENT_PATH = os.path.abspath(__file__)
+IMPORT_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(CURRENT_PATH)),
+    "imported")
 TARGET_SCRIPT_NAME = "JSON_data_files_validator.py"
 SCRIPT_URL = f"https://raw.githubusercontent.com/DARMA-tasking/vt/develop/scripts/{TARGET_SCRIPT_NAME}"
 SCRIPT_TITLE = "JSON data files validator"

--- a/src/lbaf/__init__.py
+++ b/src/lbaf/__init__.py
@@ -5,7 +5,7 @@ import sys
 import importlib
 
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 """lbaf module version"""
 
 PROJECT_PATH = f"{os.sep}".join(os.path.abspath(__file__).split(os.sep)[:-3])
@@ -38,7 +38,11 @@ def vt_data_files_validator_loader() -> int:
 
 def vt_data_files_validator():
     """Run vt_data_validator instance."""
-    JSONDataFilesValidatorLoader().run(overwrite=True)
+    # If using the lbaf package, don't overwrite
+    if importlib.util.find_spec('lbaf'):
+        JSONDataFilesValidatorLoader().run(overwrite=False)
+    else:
+        JSONDataFilesValidatorLoader().run(overwrite=True)
     from lbaf.imported.JSON_data_files_validator import JSONDataFilesValidator #pylint:disable=C0415:import-outside-toplevel
     JSONDataFilesValidator().main()
 


### PR DESCRIPTION
Fixes #475

The issue was the use of absolute file paths; since the package directory structure is slightly different from the source code (no `src` dir), we should use relative paths whenever possible.

I also changed `overwrite` to False when lbaf is installed as a package, as discussed in the meeting.