### PR TITLE
#547: Add tests for new PrescribedPermutation algorithm

### DIFF
--- a/src/lbaf/Applications/LBAF_app.py
+++ b/src/lbaf/Applications/LBAF_app.py
@@ -524,7 +524,6 @@ class LBAFApplication:
             _n_a, _w_min_max, a_min_max = lbstats.compute_min_max_arrangements_work(
                 objects, alpha, beta, gamma, n_ranks, logger=self.__logger)
         else:
-            self.__logger.info("No brute force optimization performed")
             a_min_max = []
 
         # Instantiate runtime

--- a/src/lbaf/Applications/LBAF_app.py
+++ b/src/lbaf/Applications/LBAF_app.py
@@ -414,36 +414,44 @@ class LBAFApplication:
             for o_qoi in o_qoi_list:
                 self.__logger.info(f"\t\t{o_qoi}")
 
-    def run(self):
+    def run(self, cfg=None, cfg_dir=None):
         """Run the LBAF application."""
-        # Parse command line arguments
-        self.__parse_args()
+        # If no configuration was passed directly, look for the file(s)
+        if cfg is None:
+            # Parse command line arguments
+            self.__parse_args()
 
-        # Print list of implemented QOI (according to verbosity argument)
-        self.__print_QOI()
+            # Print list of implemented QOI (according to verbosity argument)
+            self.__print_QOI()
 
-        # Warn if default configuration is used because not set as argument
-        if self.__args.configuration is None:
-            self.__logger.warning("No configuration file given. Fallback to default `conf.yaml` file in "
-                                  "working directory or in the project config directory !")
-            self.__args.configuration = "conf.yaml"
+            # Warn if default configuration is used because not set as argument
+            if self.__args.configuration is None:
+                self.__logger.warning("No configuration file given. Fallback to default `conf.yaml` file in "
+                                    "working directory or in the project config directory !")
+                self.__args.configuration = "conf.yaml"
 
-        # Find configuration files
-        config_file_list = []
-        # Global configuration (optional)
-        try:
-            config_file_list.append(self.__resolve_config_path("global.yaml"))
-        except FileNotFoundError:
-            pass
-        # Local/Specialized configuration (required)
-        try:
-            config_file_list.append(self.__resolve_config_path(self.__args.configuration))
-        except(FileNotFoundError) as err:
-            self.__logger.error(err)
-            raise SystemExit(-1) from err
+            # Find configuration files
+            config_file_list = []
 
-        # Apply configuration
-        cfg = self.__configure(*config_file_list)
+            # Global configuration (optional)
+            try:
+                config_file_list.append(self.__resolve_config_path("global.yaml"))
+            except FileNotFoundError:
+                pass
+
+            # Local/Specialized configuration (required)
+            try:
+                config_file_list.append(self.__resolve_config_path(self.__args.configuration))
+            except(FileNotFoundError) as err:
+                self.__logger.error(err)
+                raise SystemExit(-1) from err
+
+            # Apply configuration
+            cfg = self.__configure(*config_file_list)
+
+        else:
+            self.__parameters = InternalParameters(
+                config=cfg, base_dir=cfg_dir, logger=self.__logger)
 
         # Download of JSON data files validator required to continue
         loader = JSONDataFilesValidatorLoader()

--- a/tests/acceptance/test_permutations.py
+++ b/tests/acceptance/test_permutations.py
@@ -1,9 +1,5 @@
 import os
-import sys
-import subprocess
 import unittest
-import tempfile
-import yaml
 
 from src.lbaf.Applications.LBAF_app import LBAFApplication
 

--- a/tests/acceptance/test_permutations.py
+++ b/tests/acceptance/test_permutations.py
@@ -1,0 +1,111 @@
+import os
+import sys
+import subprocess
+import unittest
+import tempfile
+import yaml
+
+class TestPermutations(unittest.TestCase):
+    """Class to run acceptance tests"""
+
+    def setUp(self):
+        return
+
+    def tearDown(self):
+        return
+
+    def generate_configuration_file(self, alpha, beta, gamma, permutation):
+        """Creates and returns the path to a YAML configuration file."""
+        # Determine filepaths
+        acceptance_dir = os.path.dirname(__file__)
+        test_dir = os.path.dirname(acceptance_dir)
+        data_dir = os.path.join(os.path.dirname(test_dir), "data")
+
+        # Create YAML configuration
+        config = {
+            "from_data": {
+                "data_stem": f"{data_dir}/synthetic_lb_data/data",
+                "phase_ids": [0],
+            },
+            "check_schema": False,
+            "work_model": {
+                "name": "AffineCombination",
+                "parameters": {
+                    "alpha": alpha,
+                    "beta": beta,
+                    "gamma": gamma
+                }
+            },
+            "algorithm": {
+                "name": "PrescribedPermutation",
+                "phase_id": 0,
+                "parameters": {
+                    "permutation": permutation
+                }
+            },
+            "logging_level": "info",
+            "output_dir": os.path.join(acceptance_dir, "output"),
+            "output_file_stem": "output_file"
+        }
+
+        # Write out the configuration to a temporary file
+        tmp_cfg_file = tempfile.NamedTemporaryFile(delete=False, suffix=".yaml", mode="w")
+        with tmp_cfg_file as f:
+            yaml.dump(config, f)
+
+        # Return the path to the config file
+        return tmp_cfg_file.name
+
+    def run_test(self, config_file, test_case, expected_w_max):
+        """Compare LBAF's results to the expected W_max."""
+        # Run LBAF
+        subprocess.run(["python", "src/lbaf", "-c", config_file], check=True)
+
+        # Check w_max file exists
+        output_dir = os.path.join(os.path.dirname(__file__), "output")
+        imbalance_filepath = os.path.join(output_dir, "imbalance.txt")
+        w_max_filepath = os.path.join(output_dir, "w_max.txt")
+        self.assertTrue(os.path.isfile(w_max_filepath), f"File: {w_max_filepath} does not exist!")
+
+        # Validate w_max value
+        with open(w_max_filepath, 'r', encoding="utf-8") as w_max_file:
+            w_max = float(w_max_file.read())
+            self.assertEqual(w_max, expected_w_max, f"@@@@@ [{test_case}] FOUND W_MAX: {w_max} @@@@@")
+
+        # Clean up
+        os.remove(config_file)
+        os.remove(w_max_filepath)
+        os.remove(imbalance_filepath)
+
+    def test_ccm_permutation(self):
+        # Initialize test cases
+        test_cases = {
+            "load_only": {
+                "alpha": 1.0,
+                "beta": 0.0,
+                "gamma": 0.0,
+                "permutation": dict(enumerate([0, 0, 1, 1, 0, 2, 1, 3, 3])),
+                "W_max": 2.0
+            },
+            "off_node_communication_only": {
+                "alpha": 0.0,
+                "beta": 1.0,
+                "gamma": 0.0,
+                "permutation": dict(enumerate([3, 2, 3, 3, 2, 3, 3, 3, 3])),
+                "W_max": 0.0
+            }
+        }
+
+        # Run each test case
+        for test_case, test_params in test_cases.items():
+            cfg = self.generate_configuration_file(
+                alpha=test_params["alpha"],
+                beta=test_params["beta"],
+                gamma=test_params["gamma"],
+                permutation=test_params["permutation"]
+            )
+            self.run_test(cfg, test_case, test_params["W_max"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #547 

Cases tested in this PR:
- load-only: `W_max=2.0`
- off-node-communication-only: `W_max=0.0`

---

This PR makes the same changes as #541 to write out `w_max.txt` when we run LBAF.

I also altered the `LBAFApplication.run()` function so that we can call it directly from tests with a configuration dict. This allows us to:
1. avoid using `subprocess.run()` to call LBAF
2. avoid having to create separate configuration files for each test case

Now we can run LBAF in tests with:

```python
        # Run LBAF
        lbaf = LBAFApplication()
        lbaf.run(cfg=config, cfg_dir=acceptance_dir)
```