### PR TITLE
#551: Fix INPUT_MODULE ordering

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -34,6 +34,8 @@ jobs:
       - name: Build documentation
         working-directory: ${{ env.docs-generator }}
         run: |
+          ls
+          less python.py
           python python.py ${{ env.docs-directory }}/docs_config.py
       # .nojekyll file is needed for GitHub Pages to know it's getting a ready webpage
       # and there is no need to generate anything

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,8 +1,6 @@
 name: Deploy docs
 
-on:
-  push:
-    branches: [ 'master', 'develop' ]
+on: push
 
 jobs:
   build-and-deploy-docs:
@@ -43,7 +41,9 @@ jobs:
         working-directory: ${{ env.docs-output }}
         run: touch .nojekyll
       # This action moves the content of `generated_docs` to the `deploy-doc-site` branch
+      # It only runs on pushes to main and develop
       - name: Deploy docs
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           token: ${{ secrets.GH_PAT }}

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -34,8 +34,6 @@ jobs:
       - name: Build documentation
         working-directory: ${{ env.docs-generator }}
         run: |
-          ls
-          less python.py
           python python.py ${{ env.docs-directory }}/docs_config.py
       # .nojekyll file is needed for GitHub Pages to know it's getting a ready webpage
       # and there is no need to generate anything

--- a/docs/docs_config.py
+++ b/docs/docs_config.py
@@ -67,8 +67,6 @@ LINKS_NAVBAR1 = [
 PLUGINS = ["m.code", "m.components", "m.dox"]
 
 INPUT_MODULES = [
-    AffineCombinationWorkModel,
-    LoadOnlyWorkModel,
     Object,
     Message,
     ObjectCommunicator,
@@ -79,6 +77,8 @@ INPUT_MODULES = [
     AlgorithmBase,
     BruteForceAlgorithm,
     CriterionBase,
+    AffineCombinationWorkModel,
+    LoadOnlyWorkModel,
     InformAndTransferAlgorithm,
     PhaseStepperAlgorithm,
     Runtime,

--- a/docs/docs_config.py
+++ b/docs/docs_config.py
@@ -4,7 +4,6 @@
 import lbaf.Applications.LBAF_app as LBAF
 
 # Model
-
 import lbaf.Model.lbsAffineCombinationWorkModel as AffineCombinationWorkModel
 import lbaf.Model.lbsLoadOnlyWorkModel as LoadOnlyWorkModel
 import lbaf.Model.lbsObject as Object
@@ -67,6 +66,14 @@ LINKS_NAVBAR1 = [
 PLUGINS = ["m.code", "m.components", "m.dox"]
 
 INPUT_MODULES = [
+    lbaf.Model,
+    lbaf.Applications,
+    lbaf.Execution,
+    lbaf.imported,
+    lbaf.IO,
+    lbaf.Utils,
+    AffineCombinationWorkModel,
+    LoadOnlyWorkModel,
     Object,
     Message,
     ObjectCommunicator,
@@ -77,8 +84,6 @@ INPUT_MODULES = [
     AlgorithmBase,
     BruteForceAlgorithm,
     CriterionBase,
-    AffineCombinationWorkModel,
-    LoadOnlyWorkModel,
     InformAndTransferAlgorithm,
     PhaseStepperAlgorithm,
     Runtime,

--- a/docs/docs_config.py
+++ b/docs/docs_config.py
@@ -66,12 +66,6 @@ LINKS_NAVBAR1 = [
 PLUGINS = ["m.code", "m.components", "m.dox"]
 
 INPUT_MODULES = [
-    lbaf.Model,
-    lbaf.Applications,
-    lbaf.Execution,
-    lbaf.imported,
-    lbaf.IO,
-    lbaf.Utils,
     AffineCombinationWorkModel,
     LoadOnlyWorkModel,
     Object,

--- a/docs/docs_config.py
+++ b/docs/docs_config.py
@@ -1,9 +1,13 @@
 """Configuration to generate the documentation."""
+# LBAF
+import lbaf
 
 # Applications
+import lbaf.Applications as Applications
 import lbaf.Applications.LBAF_app as LBAF
 
 # Model
+import lbaf.Model as Model
 import lbaf.Model.lbsAffineCombinationWorkModel as AffineCombinationWorkModel
 import lbaf.Model.lbsLoadOnlyWorkModel as LoadOnlyWorkModel
 import lbaf.Model.lbsObject as Object
@@ -14,6 +18,7 @@ import lbaf.Model.lbsRank as Rank
 import lbaf.Model.lbsWorkModelBase as WorkModelBase
 
 # Execution
+import lbaf.Execution as Execution
 import lbaf.Execution.lbsAlgorithmBase as AlgorithmBase
 import lbaf.Execution.lbsBruteForceAlgorithm as BruteForceAlgorithm
 import lbaf.Execution.lbsCriterionBase as CriterionBase
@@ -24,9 +29,11 @@ import lbaf.Execution.lbsStrictLocalizingCriterion as StrictLocalizingCriterion
 import lbaf.Execution.lbsTemperedCriterion as TemperedCriterion
 
 # Imported
+import lbaf.imported as imported
 import lbaf.imported.JSON_data_files_validator as JSONDataFilesValidator
 
 # IO
+import lbaf.IO as IO
 import lbaf.IO.lbsConfigurationValidator as ConfigurationValidator
 import lbaf.IO.lbsConfigurationUpgrader as configurationUpgrader
 import lbaf.IO.lbsStatistics as lbsStatistics
@@ -34,6 +41,7 @@ import lbaf.IO.lbsVTDataReader as LoadReader
 import lbaf.IO.lbsVTDataWriter as VTDataWriter
 
 # Utilities
+import lbaf.Utils as Utils
 import lbaf.Utils.lbsCsv2JsonDataConverter as Csv2JsonConverter
 import lbaf.Utils.lbsDataStatFilesUpdater as DataStatFilesUpdater
 import lbaf.Utils.lbsLogging as logger
@@ -66,6 +74,13 @@ LINKS_NAVBAR1 = [
 PLUGINS = ["m.code", "m.components", "m.dox"]
 
 INPUT_MODULES = [
+    lbaf,
+    Applications,
+    Model,
+    Execution,
+    imported,
+    IO,
+    Utils,
     AffineCombinationWorkModel,
     LoadOnlyWorkModel,
     Object,


### PR DESCRIPTION
Fixes #551 

The problem stems from [this commit](https://github.com/mosra/m.css/commit/33265c8b79c9b2a2c460830394ad5cf9a27ead32) to `m.css`. The change is described below (copied from the linked commit's message), where the "additional check" mentioned was throwing errors for us:

```
The use case is explicitly including a module that otherwise doesn't get
transitively imported from the parents. They were treated as a standalone
root module until now, causing quite a mess. Now they aren't, but there's
an additional check requiring the user to explicitly supply also all
parents.
```

Also reworks the doc deployment pipeline so that the docs are built on every PR, but only deployed on pushes to `develop` or `main`. This way we'll catch errors in the pipeline before merging PRs.