### PR TITLE
#571: Resolve problem of shallow copying of objects that invalidates lookup table

### DIFF
--- a/src/lbaf/IO/lbsVTDataWriter.py
+++ b/src/lbaf/IO/lbsVTDataWriter.py
@@ -188,7 +188,8 @@ class VTDataWriter:
                 if len(sender_obj) == 1:
                     # Retrieve communications with single sender
                     sender_obj = sender_obj[0]
-                    sender_rank_id = self.__find_object_rank(phase, sender_obj).get_id()
+                    sender_rank_id = sender_obj.get_rank_id()
+                    #sender_rank_id = self.__find_object_rank(phase, sender_obj).get_id()
                     from_rank: Rank = [
                         r for r in phase.get_ranks() if r.get_id() == sender_rank_id][0]
                     comm_entry["from"]["home"] = sender_rank_id
@@ -208,7 +209,8 @@ class VTDataWriter:
                 if len(receiver_obj) == 1:
                     # Retrieve communications with single receiver
                     receiver_obj = receiver_obj[0]
-                    receiver_rank_id = self.__find_object_rank(phase, receiver_obj).get_id()
+                    receiver_rank_id = receiver_obj.get_rank_id()
+                    #receiver_rank_id = self.__find_object_rank(phase, receiver_obj).get_id()
                     comm_entry["to"]["home"] = receiver_rank_id
                     to_rank: Rank = [
                         r for r in phase.get_ranks() if receiver_obj in r.get_objects()][0]

--- a/src/lbaf/Model/lbsPhase.py
+++ b/src/lbaf/Model/lbsPhase.py
@@ -665,8 +665,6 @@ class Phase:
 
             # Perform sanity check
             if b_id not in r_src.get_shared_ids():
-                print(b_id)
-                print(r_src.get_shared_ids())
                 self.__logger.error(
                     f"block {b_id} not present in {r_src.get_shared_ids()}")
                 raise SystemExit(1)

--- a/src/lbaf/Model/lbsPhase.py
+++ b/src/lbaf/Model/lbsPhase.py
@@ -665,6 +665,8 @@ class Phase:
 
             # Perform sanity check
             if b_id not in r_src.get_shared_ids():
+                print(b_id)
+                print(r_src.get_shared_ids())
                 self.__logger.error(
                     f"block {b_id} not present in {r_src.get_shared_ids()}")
                 raise SystemExit(1)

--- a/src/lbaf/Model/lbsRank.py
+++ b/src/lbaf/Model/lbsRank.py
@@ -89,8 +89,8 @@ class Rank:
         self.__size = rank.get_size()
 
         # Shallow copy owned objects
-        self.__shared_blocks = copy.copy(rank.__shared_blocks)
-        self.__sentinel_objects = copy.copy(rank.__sentinel_objects)
+        self.__shared_blocks = copy.deepcopy(rank.__shared_blocks)
+        self.__sentinel_objects = copy.deepcopy(rank.__sentinel_objects)
         self.__migratable_objects = copy.copy(rank.__migratable_objects)
 
     def __lt__(self, other):
@@ -152,11 +152,16 @@ class Rank:
     def delete_shared_block(self, block: Block):
         """Try to delete shared memory block."""
         try:
-            self.__shared_blocks.remove(block)
-        except Exception as err:
+            del_block = next(
+                b for b in self.__shared_blocks
+                if b.get_id() == block.get_id())
+        except StopIteration:
             self.__logger.error(
                 f"no shared block with ID {block.get_id()} to delete on rank {self.get_id()}")
-            raise SystemExit(1) from err
+            raise SystemExit(1)
+
+        # Delete found block
+        self.__shared_blocks.remove(del_block)
 
     def get_shared_block_with_id(self, b_id: int) -> Block:
         """Return shared memory block with given ID when it exists."""


### PR DESCRIPTION
Fixes #571 

**N.B.:** This requires a slightly different handling of shared block deletion.

The only place where this change actually has an impact currently is in the vt data reader, specifically lines 191 and 211