### PR TITLE
#617: Writing out json is very slow with large files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ scipy==1.10.1
 PyYAML==6.0.1
 Brotli==1.1.0
 schema==0.7.7
+orjson>=3.10,<4
 colorama==0.4.6
 typing_extensions==4.12.2
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     PyYAML==6.0.1
     Brotli==1.1.0
     schema==0.7.7
+    orjson>=3.10,<4
     colorama==0.4.6
     typing_extensions==4.12.2
 

--- a/src/lbaf/Applications/LBAF_app.py
+++ b/src/lbaf/Applications/LBAF_app.py
@@ -597,7 +597,7 @@ class LBAFApplication:
                     # Insert rebalanced phase into dictionary of phases
                     phases[p_id] = rebalanced_phase
 
-                # Write all phasesOA
+                # Write all phases
                 self.__logger.info(
                     f"Writing all ({len(phases)}) phases for offline load-balancing")
                 self.__json_writer.write(phases)

--- a/src/lbaf/IO/lbsVTDataWriter.py
+++ b/src/lbaf/IO/lbsVTDataWriter.py
@@ -96,7 +96,7 @@ class VTDataWriter:
         try:
             self.__extension = parameters["json_output_suffix"]
             self.__compress = parameters["compressed"]
-            self.__add_communications = parameters["communications"]
+            self.__add_communications = parameters.get("communications", True)
         except Exception as e:
             self.__logger.error(
                 f"Missing JSON writer configuration parameter(s): {e}")

--- a/src/lbaf/IO/lbsVTDataWriter.py
+++ b/src/lbaf/IO/lbsVTDataWriter.py
@@ -377,6 +377,43 @@ class VTDataWriter:
         return file_name
 
     @timer
+    def __write_with_concurrency(self):
+        from concurrent.futures import ProcessPoolExecutor, as_completed
+        with ProcessPoolExecutor() as executor:
+            futures = {executor.submit(self._json_writer, item): item for item in self.__rank_phases.items()}
+            for future in as_completed(futures):
+                try:
+                    file_name = future.result()
+                    self.__logger.info(f"Wrote {file_name}")
+                except Exception as e:
+                    self.__logger.error(f"Error processing {futures[future]}: {e}")
+
+    @timer
+    def __write_with_standard_mp(self):
+        with mp.pool.Pool(context=mp.get_context("fork")) as pool:
+            results = pool.imap_unordered(
+                self._json_writer, self.__rank_phases.items())
+            for file_name in results:
+                self.__logger.info(f"Wrote {file_name}")
+
+    @timer
+    def __write_with_thread_concurrency(self):
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+        with ThreadPoolExecutor() as executor:
+            futures = {executor.submit(self._json_writer, item): item for item in self.__rank_phases.items()}
+            for future in as_completed(futures):
+                try:
+                    file_name = future.result()
+                    self.__logger.info(f"Wrote {file_name}")
+                except Exception as e:
+                    self.__logger.error(f"Error processing {futures[future]}: {e}")
+
+    @timer
+    def __write_in_serial(self):
+        for rank_phases_double in self.__rank_phases.items():
+            file_name = self._json_writer(rank_phases_double)
+            self.__logger.info(f"Wrote {file_name}")
+    @timer
     def write(self, phases: dict):
         """ Write one JSON per rank for dictonary of phases with possibly iterations."""
         # Ensure that provided phase has correct type
@@ -397,7 +434,24 @@ class VTDataWriter:
         # Prevent recursion overruns
         sys.setrecursionlimit(25000)
 
+        ######################################################################################
         # Write individual rank files
-        for rank_phases_double in self.__rank_phases.items():
-            file_name = self._json_writer(rank_phases_double)
-            self.__logger.info(f"Wrote {file_name}")
+        # try:
+        #     self.__write_with_standard_mp()
+        # except:
+        #     print("There was an error running the standard MP function.")
+
+        # try:
+        #     self.__write_with_concurrency()
+        # except:
+        #     print("There was an error with self.__write_with_concurrency")
+
+        try:
+            self.__write_with_thread_concurrency()
+        except:
+            print("There was an error with self.__write_with_thread_concurrency")
+
+        try:
+            self.__write_in_serial()
+        except:
+            print("There was an error with self.__write_in_serial")

--- a/src/lbaf/IO/lbsVTDataWriter.py
+++ b/src/lbaf/IO/lbsVTDataWriter.py
@@ -45,8 +45,6 @@ import multiprocessing as mp
 import os
 import sys
 import math
-import time
-import functools
 
 from logging import Logger
 from typing import Optional
@@ -57,16 +55,7 @@ from ..Model.lbsPhase import Phase
 from ..Model.lbsRank import Rank
 from ..Model.lbsObject import Object
 
-def timer(method):
-    @functools.wraps(method)
-    def wrapper(self, *args, **kwargs):
-        start = time.time()
-        res = method(self, *args, **kwargs)
-        end = time.time()
-        dur = end - start
-        self._VTDataWriter__logger.info(f"{method.__name__}: {dur:.4f} s")
-        return res
-    return wrapper
+from ..Utils.lbsTimerDecorator import timer
 
 class VTDataWriter:
     """A class to write load directives for VT as JSON files
@@ -404,25 +393,12 @@ class VTDataWriter:
     @timer
     def write(self, phases: dict):
         """ Write one JSON per rank for dictonary of phases with possibly iterations."""
-
-        ## REGION A
-
-        # start = time.time()
-
         # Ensure that provided phase has correct type
         if not isinstance(phases, dict):
             self.__logger.error(
                 "JSON writer must be passed a dictionary")
             raise SystemExit(1)
         self.__phases = phases
-
-        # end = time.time()
-        # dur = end - start
-        # print(f"Region A: {dur} s")
-
-        ## REGION B
-
-        # start = time.time()
 
         # Assemble mapping from ranks to their phases
         self.__rank_phases = {}
@@ -435,27 +411,7 @@ class VTDataWriter:
         # Prevent recursion overruns
         sys.setrecursionlimit(25000)
 
-        # end = time.time()
-        # dur = end - start
-        # print(f"Region B: {dur} s")
-
-        ## REGION C
-
-        # start = time.time()
-
-        # Write individual rank files using data parallelism
-        # with mp.pool.Pool(context=mp.get_context("spawn")) as pool:
-        #     self.__logger.info(f"{pool._processes} threads for {len(self.__rank_phases)} ranks.")
-        #     results = pool.imap_unordered(
-        #         self._json_writer, self.__rank_phases.items())
-        #     for file_name in results:
-        #         self.__logger.info(f"Wrote {file_name}")
-
-        # Try in serial
+        # Write individual rank files
         for rank_phases_double in self.__rank_phases.items():
             file_name = self._json_writer(rank_phases_double)
             self.__logger.info(f"Wrote {file_name}")
-
-        # end = time.time()
-        # dur = end - start
-        # print(f"Region C: {dur} s")

--- a/src/lbaf/IO/lbsVTDataWriter.py
+++ b/src/lbaf/IO/lbsVTDataWriter.py
@@ -40,7 +40,6 @@
 ###############################################################################
 #@HEADER
 #
-import json
 import multiprocessing as mp
 import os
 import sys
@@ -50,6 +49,7 @@ from logging import Logger
 from typing import Optional
 
 import brotli
+import orjson
 
 from ..Model.lbsPhase import Phase
 from ..Model.lbsRank import Rank
@@ -101,6 +101,10 @@ class VTDataWriter:
             self.__logger.error(
                 f"Missing JSON writer configuration parameter(s): {e}")
             raise SystemExit(1) from e
+
+    def __json_to_string(self, payload: dict) -> str:
+        """Serialize a payload to a compact JSON string for logging."""
+        return orjson.dumps(payload).decode("utf-8")
 
     @timer
     def __create_tasks(self, rank_id, objects, migratable):
@@ -203,7 +207,7 @@ class VTDataWriter:
                     # Other cases are not supported
                     missing_ref = comm_entry["from"].get("id", comm_entry["from"].get("seq_id"))
                     self.__logger.error(
-                        f"Invalid object id ({missing_ref}) in communication {json.dumps(comm_entry)}")
+                        f"Invalid object id ({missing_ref}) in communication {self.__json_to_string(comm_entry)}")
 
                 receiver_obj: Object = [o for o in phase.get_objects() if
                     o.get_id() is not None and o.get_id() == comm_entry["to"].get("id") or
@@ -223,13 +227,13 @@ class VTDataWriter:
                     # Other cases are not supported
                     missing_ref = comm_entry["to"].get("id", comm_entry["to"].get("seq_id"))
                     self.__logger.error(
-                        f"Invalid object id ({missing_ref}) in communication {json.dumps(comm_entry)}")
+                        f"Invalid object id ({missing_ref}) in communication {self.__json_to_string(comm_entry)}")
 
                 if missing_ref is not None:
                     # Keep communication with invalid entity references for the moment.
                     # We might remove these communications in the future in the reader work to fix invalid input.
                     self.__logger.warning(
-                        f"Missing reference: ({missing_ref}) in communication {json.dumps(comm_entry)}")
+                        f"Missing reference: ({missing_ref}) in communication {self.__json_to_string(comm_entry)}")
                     communications.append(comm_entry)
                 elif ("migratable" in comm_entry["from"].keys() and
                         not comm_entry["from"]["migratable"]):
@@ -251,7 +255,7 @@ class VTDataWriter:
         return communications
 
     @timer
-    def _json_serializer(self, rank_phases_double) -> str:
+    def _json_serializer(self, rank_phases_double) -> bytes:
         """Write one JSON per rank for list of phase instances."""
         # Unpack received double
         r_id, r_phases = rank_phases_double
@@ -351,7 +355,7 @@ class VTDataWriter:
             output["phases"].append(phase_data)
 
         # Serialize and possibly compress JSON payload
-        serial_json = json.dumps(output, separators=(',', ':'))
+        serial_json = orjson.dumps(output)
         return serial_json
 
     @timer
@@ -369,8 +373,8 @@ class VTDataWriter:
 
         if self.__compress:
             serial_json = brotli.compress(
-                string=serial_json.encode("utf-8"), mode=brotli.MODE_TEXT)
-        with open(file_name, "wb" if self.__compress else 'w') as json_file:
+                string=serial_json, mode=brotli.MODE_TEXT)
+        with open(file_name, "wb") as json_file:
             json_file.write(serial_json)
 
         # Return JSON file name
@@ -448,10 +452,7 @@ class VTDataWriter:
 
         try:
             self.__write_with_thread_concurrency()
-        except:
-            print("There was an error with self.__write_with_thread_concurrency")
-
-        try:
+        except Exception as e:
+            self.__logger.error(
+                f"There was an error with self.__write_with_thread_concurrency: {e}")
             self.__write_in_serial()
-        except:
-            print("There was an error with self.__write_in_serial")

--- a/src/lbaf/IO/lbsVTDataWriter.py
+++ b/src/lbaf/IO/lbsVTDataWriter.py
@@ -187,6 +187,9 @@ class VTDataWriter:
     def __get_communications(self, phase: Phase, rank: Rank):
         """Create communication entries to be outputted to JSON."""
 
+        if not self.__add_communications:
+            return None
+
         # Get initial communications (if any) for current phase
         phase_communications_dict = phase.get_communications()
 
@@ -324,10 +327,9 @@ class VTDataWriter:
             phase_data["user_defined"]["num_homed_ratio"] = homed_ratio
 
             # Add communication data if present
-            if self.__add_communications:
-                communications = self.__get_communications(current_phase, rank)
-                if communications:
-                    phase_data["communications"] = communications
+            communications = self.__get_communications(current_phase, rank)
+            if communications:
+                phase_data["communications"] = communications
 
             # Add load balancing iterations if present
             lb_iterations = current_phase.get_lb_iterations()
@@ -363,10 +365,9 @@ class VTDataWriter:
                         iteration_data["user_defined"]["num_homed_ratio"] = homed_ratio
 
                         # Add communication data if present
-                        if self.__add_communications:
-                            communications = self.__get_communications(it, it_r)
-                            if communications:
-                                iteration_data["communications"] = communications
+                        communications = self.__get_communications(it, it_r)
+                        if communications:
+                            iteration_data["communications"] = communications
 
                         # Append load balancing iteration to phase data
                         phase_data["lb_iterations"].append(iteration_data)
@@ -404,6 +405,10 @@ class VTDataWriter:
     def write(self, phases: dict):
         """ Write one JSON per rank for dictonary of phases with possibly iterations."""
 
+        ## REGION A
+
+        # start = time.time()
+
         # Ensure that provided phase has correct type
         if not isinstance(phases, dict):
             self.__logger.error(
@@ -411,10 +416,18 @@ class VTDataWriter:
             raise SystemExit(1)
         self.__phases = phases
 
+        # end = time.time()
+        # dur = end - start
+        # print(f"Region A: {dur} s")
+
+        ## REGION B
+
+        # start = time.time()
+
         # Assemble mapping from ranks to their phases
         self.__rank_phases = {}
         for phase in self.__phases.values():
-            # Handle case where entry only cintains a phase
+            # Handle case where entry only contains a phase
             for r in phase.get_ranks():
                 self.__rank_phases.setdefault(r.get_id(), {})
                 self.__rank_phases[r.get_id()][phase.get_id()] = r
@@ -422,9 +435,27 @@ class VTDataWriter:
         # Prevent recursion overruns
         sys.setrecursionlimit(25000)
 
+        # end = time.time()
+        # dur = end - start
+        # print(f"Region B: {dur} s")
+
+        ## REGION C
+
+        # start = time.time()
+
         # Write individual rank files using data parallelism
-        with mp.pool.Pool(context=mp.get_context("fork")) as pool:
-            results = pool.imap_unordered(
-                self._json_writer, self.__rank_phases.items())
-            for file_name in results:
-                self.__logger.info(f"Wrote {file_name}")
+        # with mp.pool.Pool(context=mp.get_context("spawn")) as pool:
+        #     self.__logger.info(f"{pool._processes} threads for {len(self.__rank_phases)} ranks.")
+        #     results = pool.imap_unordered(
+        #         self._json_writer, self.__rank_phases.items())
+        #     for file_name in results:
+        #         self.__logger.info(f"Wrote {file_name}")
+
+        # Try in serial
+        for rank_phases_double in self.__rank_phases.items():
+            file_name = self._json_writer(rank_phases_double)
+            self.__logger.info(f"Wrote {file_name}")
+
+        # end = time.time()
+        # dur = end - start
+        # print(f"Region C: {dur} s")

--- a/src/lbaf/IO/lbsVTDataWriter.py
+++ b/src/lbaf/IO/lbsVTDataWriter.py
@@ -45,6 +45,9 @@ import multiprocessing as mp
 import os
 import sys
 import math
+import time
+import functools
+
 from logging import Logger
 from typing import Optional
 
@@ -54,6 +57,16 @@ from ..Model.lbsPhase import Phase
 from ..Model.lbsRank import Rank
 from ..Model.lbsObject import Object
 
+def timer(method):
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        start = time.time()
+        res = method(self, *args, **kwargs)
+        end = time.time()
+        dur = end - start
+        self._VTDataWriter__logger.info(f"{method.__name__}: {dur:.4f} s")
+        return res
+    return wrapper
 
 class VTDataWriter:
     """A class to write load directives for VT as JSON files
@@ -94,11 +107,13 @@ class VTDataWriter:
         try:
             self.__extension = parameters["json_output_suffix"]
             self.__compress = parameters["compressed"]
+            self.__add_communications = parameters["communications"]
         except Exception as e:
             self.__logger.error(
                 f"Missing JSON writer configuration parameter(s): {e}")
             raise SystemExit(1) from e
 
+    @timer
     def __create_tasks(self, rank_id, objects, migratable):
         """Create per-object entries to be outputted to JSON."""
         tasks = []
@@ -145,6 +160,7 @@ class VTDataWriter:
         # Return created tasks on this rank
         return tasks
 
+    @timer
     def __create_task_data(self, rank: Rank):
         """Create task data."""
         return sorted(
@@ -155,6 +171,7 @@ class VTDataWriter:
             key=lambda x: x.get("entity").get(
                 "id", x.get("entity").get("seq_id")))
 
+    @timer
     def __find_object_rank(self, phase: Phase, obj: Object):
         """Determine which rank owns the object."""
         for r in phase.get_ranks():
@@ -166,6 +183,7 @@ class VTDataWriter:
             f"Object id {object} cannot be located in any rank of phase {phase.get_id()}")
         raise SystemExit(1)
 
+    @timer
     def __get_communications(self, phase: Phase, rank: Rank):
         """Create communication entries to be outputted to JSON."""
 
@@ -254,6 +272,7 @@ class VTDataWriter:
         # Return created list of communications
         return communications
 
+    @timer
     def _json_serializer(self, rank_phases_double) -> str:
         """Write one JSON per rank for list of phase instances."""
         # Unpack received double
@@ -305,9 +324,10 @@ class VTDataWriter:
             phase_data["user_defined"]["num_homed_ratio"] = homed_ratio
 
             # Add communication data if present
-            communications = self.__get_communications(current_phase, rank)
-            if communications:
-                phase_data["communications"] = communications
+            if self.__add_communications:
+                communications = self.__get_communications(current_phase, rank)
+                if communications:
+                    phase_data["communications"] = communications
 
             # Add load balancing iterations if present
             lb_iterations = current_phase.get_lb_iterations()
@@ -343,9 +363,10 @@ class VTDataWriter:
                         iteration_data["user_defined"]["num_homed_ratio"] = homed_ratio
 
                         # Add communication data if present
-                        communications = self.__get_communications(it, it_r)
-                        if communications:
-                            iteration_data["communications"] = communications
+                        if self.__add_communications:
+                            communications = self.__get_communications(it, it_r)
+                            if communications:
+                                iteration_data["communications"] = communications
 
                         # Append load balancing iteration to phase data
                         phase_data["lb_iterations"].append(iteration_data)
@@ -357,6 +378,7 @@ class VTDataWriter:
         serial_json = json.dumps(output, separators=(',', ':'))
         return serial_json
 
+    @timer
     def _json_writer(self, rank_phases_double) -> str:
         """Write one JSON per rank for list of phase instances."""
         # Unpack received double
@@ -378,6 +400,7 @@ class VTDataWriter:
         # Return JSON file name
         return file_name
 
+    @timer
     def write(self, phases: dict):
         """ Write one JSON per rank for dictonary of phases with possibly iterations."""
 

--- a/src/lbaf/IO/lbsVTDataWriter.py
+++ b/src/lbaf/IO/lbsVTDataWriter.py
@@ -161,18 +161,6 @@ class VTDataWriter:
                 "id", x.get("entity").get("seq_id")))
 
     @timer
-    def __find_object_rank(self, phase: Phase, obj: Object):
-        """Determine which rank owns the object."""
-        for r in phase.get_ranks():
-            if obj in r.get_objects():
-                return r
-
-        # If this point is reached the object could not be found
-        self.__logger.error(
-            f"Object id {object} cannot be located in any rank of phase {phase.get_id()}")
-        raise SystemExit(1)
-
-    @timer
     def __get_communications(self, phase: Phase, rank: Rank):
         """Create communication entries to be outputted to JSON."""
 
@@ -204,7 +192,6 @@ class VTDataWriter:
                     # Retrieve communications with single sender
                     sender_obj = sender_obj[0]
                     sender_rank_id = sender_obj.get_rank_id()
-                    #sender_rank_id = self.__find_object_rank(phase, sender_obj).get_id()
                     from_rank: Rank = [
                         r for r in phase.get_ranks() if r.get_id() == sender_rank_id][0]
                     comm_entry["from"]["home"] = sender_rank_id
@@ -225,7 +212,6 @@ class VTDataWriter:
                     # Retrieve communications with single receiver
                     receiver_obj = receiver_obj[0]
                     receiver_rank_id = receiver_obj.get_rank_id()
-                    #receiver_rank_id = self.__find_object_rank(phase, receiver_obj).get_id()
                     comm_entry["to"]["home"] = receiver_rank_id
                     to_rank: Rank = [
                         r for r in phase.get_ranks() if receiver_obj in r.get_objects()][0]

--- a/src/lbaf/Utils/lbsTimerDecorator.py
+++ b/src/lbaf/Utils/lbsTimerDecorator.py
@@ -14,7 +14,7 @@ def timer(method):
 
         # Get a logger instance (stacklevel=2 uses the logger from the function being decorated)
         logger = logging.getLogger(self.__class__.__module__)
-        logger.debug(f"{method.__name__}: {dur:.4f} s", stacklevel=2)
+        logger.info(f"{method.__name__}: {dur:.4f} s", stacklevel=2)
 
         return res
     return wrapper

--- a/src/lbaf/Utils/lbsTimerDecorator.py
+++ b/src/lbaf/Utils/lbsTimerDecorator.py
@@ -1,0 +1,20 @@
+import time
+import logging
+import functools
+
+def timer(method):
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        """Times the execution of the decorated function."""
+        # Time the function duration
+        start = time.time()
+        res = method(self, *args, **kwargs)
+        end = time.time()
+        dur = end - start
+
+        # Get a logger instance (stacklevel=2 uses the logger from the function being decorated)
+        logger = logging.getLogger(self.__class__.__module__)
+        logger.debug(f"{method.__name__}: {dur:.4f} s", stacklevel=2)
+
+        return res
+    return wrapper


### PR DESCRIPTION
Fixes #617 

Explanation: Since writing JSON is a fairly small task, Python multiprocessing was introducing unneeded overhead. It's much faster to just write everything in serial: for the problem in question, the `write()` call went from taking 5 minutes down to 4 seconds